### PR TITLE
[TASK] Remove usage of invalid functions

### DIFF
--- a/class.tx_crawler_lib.php
+++ b/class.tx_crawler_lib.php
@@ -746,7 +746,6 @@ class tx_crawler_lib {
 
 							// Table exists:
 						if (isset($TCA[$subpartParams['_TABLE']]))	{
-							\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA($subpartParams['_TABLE']);
 							$lookUpPid = isset($subpartParams['_PID']) ? intval($subpartParams['_PID']) : $pid;
 							$pidField = isset($subpartParams['_PIDFIELD']) ? trim($subpartParams['_PIDFIELD']) : 'pid';
 							$where = isset($subpartParams['_WHERE']) ? $subpartParams['_WHERE'] : '';

--- a/class.tx_crawler_lib.php
+++ b/class.tx_crawler_lib.php
@@ -746,6 +746,10 @@ class tx_crawler_lib {
 
 							// Table exists:
 						if (isset($TCA[$subpartParams['_TABLE']]))	{
+							if (version_compare(TYPO3_version, '7.0.0', '<=')) {
+								\TYPO3\CMS\Core\Utility\GeneralUtility::loadTCA($subpartParams['_TABLE']);
+							}
+
 							$lookUpPid = isset($subpartParams['_PID']) ? intval($subpartParams['_PID']) : $pid;
 							$pidField = isset($subpartParams['_PIDFIELD']) ? trim($subpartParams['_PIDFIELD']) : 'pid';
 							$where = isset($subpartParams['_WHERE']) ? $subpartParams['_WHERE'] : '';


### PR DESCRIPTION
Fixes issue #40

According to this page: https://docs.typo3.org/typo3cms/extensions/core/latest/Changelog/7.0/Breaking-61785-LoadTcaFunctionRemoved.html this function call can be removed completely.