### PR TITLE
[TASK] Deleting old tx_crawler_processes entries ends up in slow query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,19 +58,14 @@ before_install:
 before_script:
   # Installs TYPO3
   - composer require typo3/cms=$TYPO3_VERSION
-   # If TYPO3_VERSION is NOT 6.2.x
-  - >
-    if [[ "$TYPO3_VERSION" != "^6.2" ]]; then
-      export "TYPO3_PATH_WEB"=$PWD/.Build/Web;
-    else
-      export "TYPO3_PATH_WEB"=$PWD;
-    fi
-  # Restore composer.json
+    # Restore composer.json
   - git checkout composer.json
+  - export "TYPO3_PATH_WEB"=$PWD/.Build/Web;
   # Locating UnitTests.xml
   - export "UNIT_XML"=`find . -name 'UnitTests.xml' -type f`
   # Location FunctionalTests.xml
   - export "FUNCTIONAL_XML"=`find . -name 'FunctionalTests.xml' -type f`
+  - ln -nfs .Build/vendor/typo3/cms/typo3 typo3
 
 script:
   - >

--- a/class.tx_crawler_lib.php
+++ b/class.tx_crawler_lib.php
@@ -2207,6 +2207,7 @@ class tx_crawler_lib {
 			}
 
 			$this->CLI_releaseProcesses($orphanProcesses, true); // maybe this should be somehow included into the current lock
+			$this->CLI_deleteProcessesMarkedDeleted();
 
 			$this->db->sql_query('COMMIT');
 
@@ -2241,7 +2242,7 @@ class tx_crawler_lib {
 			'process_id IN (SELECT process_id FROM tx_crawler_process WHERE active=0 AND deleted=0)',
 			array(
 				'process_scheduled' => 0,
-			'process_id' => ''
+				'process_id' => ''
 			)
 		);
 		$this->db->exec_UPDATEquery(
@@ -2277,6 +2278,15 @@ class tx_crawler_lib {
 		if(!$withinLock) $this->db->sql_query('COMMIT');
 
 		return true;
+	}
+
+	/**
+	 * Delete processes marked as deleted
+	 *
+	 * @return void
+	 */
+ 	public function CLI_deleteProcessesMarkedDeleted() {
+		$this->db->exec_DELETEquery('tx_crawler_process', 'deleted = 1');
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,10 @@
     "autoload": {
         "classmap": [
             "."
-        ]
+        ],
+        "psr-4": {
+            "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/core/Tests/"
+        }
     },
     "license": "GPL-3.0",
     "type": "typo3-cms-extension",
@@ -35,9 +38,7 @@
     "scripts": {
         "post-autoload-dump": [
             "mkdir -p .Build/Web/typo3conf/ext/",
-            "[ -L .Build/Web/typo3conf/ext/crawler ] || ln -snvf ../../../../. .Build/Web/typo3conf/ext/crawler",
-            "mkdir -p typo3conf/ext",
-            "[ -L typo3conf/ext/crawler ] || ln -snvf ../../. typo3conf/ext/crawler"
+            "[ -L .Build/Web/typo3conf/ext/crawler ] || ln -snvf ../../../../. .Build/Web/typo3conf/ext/crawler"
         ]
     },
     "extra": {


### PR DESCRIPTION
Resolves issue #8 

I've added the CLI_deleteProcessMarkedDeleted() to keep the process list smaller and therefor the slow query problem should be solved.