### PR TITLE
#107 Fixes deprecated notices

### DIFF
--- a/cli/class.tx_crawler_cli.php
+++ b/cli/class.tx_crawler_cli.php
@@ -42,7 +42,7 @@ class tx_crawler_cli extends \TYPO3\CMS\Core\Controller\CommandLineController {
 	 *
 	 * @return	void
 	 */
-	function tx_crawler_cli() {
+	function __construct() {
 		parent::__construct();
 
 		$this->cli_options[] = array('-h', 'Show the help', '');

--- a/cli/class.tx_crawler_cli_flush.php
+++ b/cli/class.tx_crawler_cli_flush.php
@@ -42,7 +42,7 @@ class tx_crawler_cli_flush extends \TYPO3\CMS\Core\Controller\CommandLineControl
 	 *
 	 * @return	void
 	 */
-	function tx_crawler_cli_flush() {
+	function __construct() {
 		parent::__construct();
 
 			// Adding options to help archive:

--- a/cli/class.tx_crawler_cli_im.php
+++ b/cli/class.tx_crawler_cli_im.php
@@ -42,7 +42,7 @@ class tx_crawler_cli_im extends \TYPO3\CMS\Core\Controller\CommandLineController
 	 *
 	 * @return	void
 	 */
-	function tx_crawler_cli_im() {
+	function __construct() {
 		parent::__construct();
 
 		// Adding options to help archive:


### PR DESCRIPTION
Some cli classes throw a deprecation notice using PHP 7 because they are not using __construct as constructor method name.

Core: Error handler (BE): PHP Runtime Deprecation Notice: Methods with the same name as their class will not be constructors in a future version of PHP; tx_crawler_cli_im has a deprecated constructor in typo3conf/ext/crawler/cli/class.tx_crawler_cli_im.php line 38