### PR TITLE
[BUGFIX] Fixed incorrect class name in ClassAliasMap

### DIFF
--- a/Migrations/Code/ClassAliasMap.php
+++ b/Migrations/Code/ClassAliasMap.php
@@ -3,5 +3,5 @@ return array(
 	'tx_crawler_scheduler_flush' => 'AOE\\Crawler\\Task\\FlushQueueTask',
 	'tx_crawler_scheduler_im' => 'AOE\\Crawler\\Task\\CrawlerQueueTask',
 	'tx_crawler_scheduler_crawlMultiProcess' => 'AOE\\Crawler\\Task\\CrawlMultiProcessTask',
-	'tx_crawler_scheduler_crawl' => 'AOE\\Crawler\\Tasks\\CrawlerTask'
+	'tx_crawler_scheduler_crawl' => 'AOE\\Crawler\\Task\\CrawlerTask'
 );


### PR DESCRIPTION
The namespace for the CrawlerTask was incorrect.