### PR TITLE
[BUGFIX] 8.x compatibility

### DIFF
--- a/Configuration/TCA/tx_crawler_configuration.php
+++ b/Configuration/TCA/tx_crawler_configuration.php
@@ -26,7 +26,7 @@ $GLOBALS['TCA']['tx_crawler_configuration'] = array(
     'columns' => array(
         'hidden' => array(
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.hidden',
+            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => array(
                 'type' => 'check',
                 'default' => '0'
@@ -142,7 +142,6 @@ $GLOBALS['TCA']['tx_crawler_configuration'] = array(
         'realurl' => Array(
             'exclude' => 1,
             'label' => 'LLL:EXT:crawler/Resources/Private/Language/Backend.xlf:tx_crawler_configuration.realurl',
-            'displayCond' => 'FALSE',
             'config' => Array(
                 'type' => 'check',
             )

--- a/class.tx_crawler_lib.php
+++ b/class.tx_crawler_lib.php
@@ -22,9 +22,9 @@
  *
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
-
-use TYPO3\CMS\Core\Imaging\Icon;
-use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Class tx_crawler_lib
@@ -1622,14 +1622,18 @@ class tx_crawler_lib {
         $tree->init('AND ' . $perms_clause);
 
         $pageinfo = \TYPO3\CMS\Backend\Utility\BackendUtility::readPageAccess($id, $perms_clause);
-        /** @var \TYPO3\CMS\Core\Imaging\IconFactory $iconFactory */
-        $iconFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(IconFactory::class);
-
-            // Set root row:
-        $tree->tree[] = [
-            'row' => $pageinfo,
-            'HTML' => $iconFactory->getIconForRecord('pages', $pageinfo, Icon::SIZE_SMALL)->render()
-        ];
+        if (VersionNumberUtility::convertVersionNumberToInteger(VersionNumberUtility::getCurrentTypo3Version()) < 8000000) {
+            $tree->tree[] = Array(
+                'row' => $pageinfo,
+                'HTML' => \TYPO3\CMS\Backend\Utility\IconUtility::getSpriteIconForRecord('pages', $pageinfo)
+            );
+        } else {
+            $iconFactory = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Imaging\\IconFactory');
+            $tree->tree[] = Array(
+                'row' => $pageinfo,
+                'HTML' => $iconFactory->getIconForRecord('pages', BackendUtility::getRecord('pages', $id))->render()
+            );
+        }
 
             // Get branch beneath:
         if ($depth)    {

--- a/modfunc1/class.tx_crawler_modfunc1.php
+++ b/modfunc1/class.tx_crawler_modfunc1.php
@@ -21,14 +21,16 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
+use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+
 /**
  * Module extension (addition to function menu) 'Site Crawler' for the 'crawler' extension.
  *
  * @author	Kasper Skaarhoj <kasperYYYY@typo3.com>
  */
 
-use TYPO3\CMS\Core\Imaging\Icon;
-use TYPO3\CMS\Core\Imaging\IconFactory;
 
 /**
  * Crawler backend module
@@ -572,12 +574,18 @@ class tx_crawler_modfunc1 extends \TYPO3\CMS\Backend\Module\AbstractFunctionModu
 					$tree->init('AND '.$perms_clause);
 
 						// Set root row:
-                    /** @var \TYPO3\CMS\Core\Imaging\IconFactory $iconFactory */
-                    $iconFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(IconFactory::class);
-
+                    if (VersionNumberUtility::convertVersionNumberToInteger(VersionNumberUtility::getCurrentTypo3Version()) < 8000000) {
+                        $HTML = \TYPO3\CMS\Backend\Utility\IconUtility::getSpriteIconForRecord(
+                            'pages',
+                            $this->pObj->pageinfo
+                        );
+                    } else {
+                        $iconFactory = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Imaging\\IconFactory');
+                        $HTML = $iconFactory->getIconForRecord('pages', $this->pObj->pageinfo, Icon::SIZE_SMALL)->render();
+                    }
 					$tree->tree[] = Array(
 						'row' => $this->pObj->pageinfo,
-						'HTML' => $iconFactory->getIconForRecord('pages', $this->pObj->pageinfo, Icon::SIZE_SMALL)->render()
+						'HTML' => $HTML
 					);
 
 						// Get branch beneath:


### PR DESCRIPTION
Make the extension work with TYPO3 CMS 8.x (8.6.0 especially):
* fix broken language label references
* remove invalid displayCondition "FALSE"
* replace IconUtility with IconFactory for 8.0.0 and above
* remove call to removed methods
