### PR TITLE
Show exception message

### DIFF
--- a/class.tx_crawler_lib.php
+++ b/class.tx_crawler_lib.php
@@ -1883,6 +1883,7 @@ class tx_crawler_lib {
                     // Run process:
                 $result = $this->CLI_run($countInARun, $sleepTime, $sleepAfterFinish);
             } catch (Exception $e) {
+                $this->CLI_debug(get_class($e) . ': ' . $e->getMessage());
                 $result = self::CLI_STATUS_ABORTED;
             }
 

--- a/class.tx_crawler_lib.php
+++ b/class.tx_crawler_lib.php
@@ -2232,7 +2232,7 @@ class tx_crawler_lib {
 
                 // if there are less than allowed active processes then add a new one
             if ($processCount < intval($this->extensionSettings['processLimit'])) {
-                $this->CLI_debug("add ".$this->CLI_buildProcessId()." (".($processCount+1)."/".intval($this->extensionSettings['processLimit']).")");
+                $this->CLI_debug("add process ".$this->CLI_buildProcessId()." (".($processCount+1)."/".intval($this->extensionSettings['processLimit']).")");
 
                     // create new process record
                 $this->db->exec_INSERTquery(


### PR DESCRIPTION
When an exception is thrown during crawling - e.g. because a hook throws one - it was caught without notice. This cost me 6 hours of debugging.

Now it is shown in debug output.