### PR TITLE
remove removed spacer method call

### DIFF
--- a/modfunc1/class.tx_crawler_modfunc1.php
+++ b/modfunc1/class.tx_crawler_modfunc1.php
@@ -222,8 +222,7 @@ class tx_crawler_modfunc1 extends \TYPO3\CMS\Backend\Module\AbstractFunctionModu
 					);
 		}
 
-		$theOutput= $this->pObj->doc->spacer(5);
-		$theOutput.= $this->pObj->doc->section($LANG->getLL('title'), $h_func, 0, 1);
+		$theOutput = $this->pObj->doc->section($LANG->getLL('title'), $h_func, 0, 1);
 
 			// Branch based on type:
 		switch ((string)$this->pObj->MOD_SETTINGS['crawlaction']) {


### PR DESCRIPTION
remove removed spacer method call 

see https://docs.typo3.org/typo3cms/extensions/core/7.6/Changelog/7.6/Deprecation-71153-DocumentTemplateSpacer.html