### PR TITLE
Prevent stopping the process when a page cannot be found

### DIFF
--- a/class.tx_crawler_lib.php
+++ b/class.tx_crawler_lib.php
@@ -2472,7 +2472,11 @@ class tx_crawler_lib {
             $GLOBALS['TT']->start();
         }
 
-        $GLOBALS['TSFE'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController',  $GLOBALS['TYPO3_CONF_VARS'], $id, $typeNum);
+        // Disable page not found handling, so a 404 would not stop the whole process.
+        $typo3_conf_vars = $GLOBALS['TYPO3_CONF_VARS'];
+		$typo3_conf_vars['FE']['pageNotFound_handling'] = 0;
+        
+        $GLOBALS['TSFE'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController', $typo3_conf_vars, $id, $typeNum);
         $GLOBALS['TSFE']->sys_page = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Page\\PageRepository');
         $GLOBALS['TSFE']->sys_page->init(TRUE);
         $GLOBALS['TSFE']->connectToDB();


### PR DESCRIPTION
At the moment the following code causes the whole crawler to stop, if a page cannot be found:
```php
public function pageNotFoundAndExit($reason = '', $header = '')
{
        $header = $header ?: $GLOBALS['TYPO3_CONF_VARS']['FE']['pageNotFound_handling_statheader'];
        $this->pageNotFoundHandler($GLOBALS['TYPO3_CONF_VARS']['FE']['pageNotFound_handling'], $header, $reason);
        die;
}
```
See https://github.com/TYPO3/TYPO3.CMS/blob/7df7dee3a9c155e0d9fc0c82b878dccb1dcb5c66/typo3/sysext/frontend/Classes/Controller/TypoScriptFrontendController.php#L1901.
This happens inside the TypoScriptFrontendController after calling $GLOBALS['TSFE']->initFEuser();. 
After the process was stopped, the next crawling process will try to crawl the same page again. So this will stop the whole crawling until somebody manually cleans the queue.

I propose to disable pageNotFound_handling, so a 404 would be logged in the crawler log, but the other pages would still be crawled normally.