### PR TITLE
[BUGFIX] Check if key exists before using count()

### DIFF
--- a/Classes/Event/EventDispatcher.php
+++ b/Classes/Event/EventDispatcher.php
@@ -116,7 +116,7 @@ class EventDispatcher
      */
     public function hasObserver($event)
     {
-        return count($this->observers[$event]) > 0;
+        return isset($this->observers[$event]) && count($this->observers[$event]) > 0;
     }
 
     /**


### PR DESCRIPTION
The array-index is undefined if the checked event has no observers.
This leads to a warning with PHP 7.2, because count() must only be used
on arrays or objects which implements Countable.