### PR TITLE
[TASK] Change branch-alias for dev-master to 6.1.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "6.1.0"
+            "dev-master": "6.1.x-dev"
         },
         "typo3/cms": {
             "cms-package-dir": "{$vendor-dir}/typo3/cms",


### PR DESCRIPTION
The `branch-alias` should point to a dev version which is always higher than the last release. Otherwise, a custom source for the package is ignored because it is older than upstream...