### PR TITLE
[BUGFIX] Fix missing locallang labels for TYPO3 7.6

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -6,4 +6,12 @@ if ('BE' === TYPO3_MODE) {
     \AOE\Crawler\Utility\BackendUtility::registerClickMenuItem();
     \AOE\Crawler\Utility\BackendUtility::registerContextSensitiveHelpForTcaFields();
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_crawler_configuration');
+
+    $isVersion7 = \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < 8000000;
+    if ($isVersion7) {
+        $mappings = ['core', 'general'];
+        foreach ($mappings as $mapping) {
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['locallangXMLOverride']['EXT:lang/Resources/Private/Language/locallang_' . $mapping . '.xlf'][] = 'EXT:lang/locallang_' . $mapping . '.xlf';
+        }
+    }
 }


### PR DESCRIPTION
Many core labels are gone in TYPO3 7.6 because the path for `locallang_core.php` and `locallang_general.php` was changed in EXT:crawler 6.0.

This fix will define an alternative location for the two files.

Note: I copied and adapted this fix from EXTnews. Credits for the solution go to @georgringer. Thank you!