### PR TITLE
[BUGFIX] Create file which is expected by TYPO3 CMS

### DIFF
--- a/class.tx_crawler_lib.php
+++ b/class.tx_crawler_lib.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * Add fallback for TYPO3 CMS 7.6 which still expects this file to exist.
+ * see https://github.com/AOEpeople/crawler/issues/262
+ */
+require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('crawler', 'Migrations/Code/LegacyClassesForIde.php'));


### PR DESCRIPTION
TYPO3 CMS expects this file to exist, see #262.

The real issue will be fixed by adding a hook to TYPO3 CMS.
Until this happens, the following hotfix will apply.