### PR TITLE
[CLEANUP] Remove obsolete TCA feInterface config

### DIFF
--- a/Configuration/TCA/tx_crawler_configuration.php
+++ b/Configuration/TCA/tx_crawler_configuration.php
@@ -17,9 +17,6 @@ $GLOBALS['TCA']['tx_crawler_configuration'] = [
         ],
         'iconfile' => 'EXT:crawler/Resources/Public/Icons/icon_tx_crawler_configuration.gif',
     ],
-    'feInterface' => [
-        'fe_admin_fieldList' => 'hidden, name, force_ssl, processing_instruction_filter, processing_instruction_parameters_ts, configuration, base_url, sys_domain_base_url, pidsonly, begroups,fegroups, realurl, chash, exclude',
-    ],
     'interface' => [
         'showRecordFieldList' => 'hidden,name,force_ssl,processing_instruction_filter,processing_instruction_parameters_ts,configuration,base_url,pidsonly,begroups,realurl,chash, exclude'
     ],


### PR DESCRIPTION
feInterface-section in TCA configuration is deprecated since 6.0 and removed with 6.2.

See also: https://docs.typo3.org/typo3cms/TCAReference/6.0/Reference/Feinterface/Index.html