### PR TITLE
[BUGFIX] Fix call-time pass-by-reference error

### DIFF
--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -1319,10 +1319,11 @@ class CrawlerController
             );
         }
 
+        $signalArguments = [$queueId, &$queueRec];
         SignalSlotUtility::emitSignal(
             __CLASS__,
             SignalSlotUtility::SIGNNAL_QUEUEITEM_PREPROCESS,
-            [$queueId, &$queueRec]
+            $signalArguments
         );
 
         // Set exec_time to lock record:
@@ -1357,10 +1358,11 @@ class CrawlerController
         // Set result in log which also denotes the end of the processing of this entry.
         $field_array = ['result_data' => serialize($result)];
 
+        $signalArguments = [$queueId, &$field_array];
         SignalSlotUtility::emitSignal(
             __CLASS__,
             SignalSlotUtility::SIGNNAL_QUEUEITEM_POSTPROCESS,
-            [$queueId, &$field_array]
+            $signalArguments
         );
 
         $this->db->exec_UPDATEquery('tx_crawler_queue', 'qid=' . intval($queueId), $field_array);
@@ -1392,10 +1394,11 @@ class CrawlerController
         // Set result in log which also denotes the end of the processing of this entry.
         $field_array = ['result_data' => serialize($result)];
 
+        $signalArguments = [$queueId, &$field_array];
         SignalSlotUtility::emitSignal(
             __CLASS__,
             SignalSlotUtility::SIGNNAL_QUEUEITEM_POSTPROCESS,
-            [$queueId, &$field_array]
+            $signalArguments
         );
 
         $this->db->exec_UPDATEquery('tx_crawler_queue', 'qid=' . intval($queueId), $field_array);


### PR DESCRIPTION
Signal arguments are passed as reference which cause
'Using a call-time pass-by-reference is deprecated since PHP 5.3 and
prohibited since PHP 5.4' php errors.

I got this errors when doing static code analysis using phpcodesniffer's phpcompatibility check for php 7.2.