### PR TITLE
[BUG] Composer: Move system dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">= 5.6, < 7.4",
-        "ext-posix": "*",
         "ext-filter": "*",
         "typo3/cms-core": ">=7.6.0",
         "typo3/cms-backend": "*",
@@ -33,6 +32,9 @@
     },
     "replace": {
         "typo3-ter/crawler": "self.version"
+    },
+    "suggest": {
+        "ext-posix": "Extension to enable software compatibility with variants of Unix, used for shell commands in crawler"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The package requires the PHP extension »posix« to be installed
on the system. The posix extension however is not available for Windows.

This causes failed installations of crawler on Windows systems.

Only suggest the installation of the extension and dont make it
a requirement anymore to allow installations on both Unix and Windows.

Refs #384