### PR TITLE
[BUGFIX] Use correct method names

### DIFF
--- a/template/process/list.php
+++ b/template/process/list.php
@@ -55,13 +55,13 @@
 		<?php foreach ($this->getProcessCollection() as $process): /* @var $process \AOE\Crawler\Domain\Model\Process */ ?>
 			<tr class="<?php echo (++$count % 2 == 0) ? 'odd' : 'even' ?>">
 				<td><?php echo $this->getIconForState(htmlspecialchars($process->getState())); ?></td>
-				<td><?php echo htmlspecialchars($process->getProcess_id()); ?></td>
+				<td><?php echo htmlspecialchars($process->getProcessId()); ?></td>
 				<td><?php echo htmlspecialchars($this->asDate($process->getTimeForFirstItem())); ?></td>
 				<td><?php echo htmlspecialchars($this->asDate($process->getTimeForLastItem())); ?></td>
 				<td><?php echo htmlspecialchars(floor($process->getRuntime() / 60)); ?> min. <?php echo htmlspecialchars($process->getRuntime()) % 60 ?> sec.</td>
 				<td><?php echo htmlspecialchars($this->asDate($process->getTTL())); ?></td>
 				<td><?php echo htmlspecialchars($process->countItemsProcessed()); ?></td>
-				<td><?php echo htmlspecialchars($process->countItemsAssigned()); ?></td>
+				<td><?php echo htmlspecialchars($process->getAssignedItemsCount()); ?></td>
 				<td><?php echo htmlspecialchars($process->countItemsToProcess() + $process->countItemsProcessed()); ?></td>
 				<td>
 				<?php if ($process->getState() == 'running'): ?>


### PR DESCRIPTION
I'm getting errors in backend in "Crawling Processes" view because of non-existing methods. This PR fixes that.