### PR TITLE
[BUGFIX] Fix typo in queryBuilder

### DIFF
--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -2325,7 +2325,7 @@ class CrawlerController
                 ->where(
                     $queryBuilder->expr()->in('qid', $quidList)
                 )
-                ->set('process_scheduled', $queryBuilder->createNamedParamter($this->getCurrentTime(), \PDO::PARAM_INT))
+                ->set('process_scheduled', $queryBuilder->createNamedParameter($this->getCurrentTime(), \PDO::PARAM_INT))
                 ->set('process_id', $processId)
                 ->execute();
 


### PR DESCRIPTION
A minor typo leads to PHP error (method not found).

The PR fixes the database query / method call.

Closes: #423