### PR TITLE
[TASK] Clean up CrawlerController

### DIFF
--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -327,7 +327,7 @@ class CrawlerController implements LoggerAwareInterface
 
         if (!$skipPage) {
             // veto hook
-            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['crawler']['pageVeto'] ?? []as $key => $func) {
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['crawler']['pageVeto'] ?? [] as $key => $func) {
                 $params = [
                     'pageRow' => $pageRow
                 ];
@@ -626,7 +626,7 @@ class CrawlerController implements LoggerAwareInterface
                 ->execute()
                 ->fetchAll();
 
-            foreach ($configurationRecordsForCurrentPage ?? []as $configurationRecord) {
+            foreach ($configurationRecordsForCurrentPage ?? [] as $configurationRecord) {
 
                     // check access to the configuration record
                 if (empty($configurationRecord['begroups']) || $GLOBALS['BE_USER']->isAdmin() || $this->hasGroupAccess($GLOBALS['BE_USER']->user['usergroup_cached_list'], $configurationRecord['begroups'])) {


### PR DESCRIPTION
This patch cleans up CrawlerController in some areas:

- remove unused cli_* methods and properties
- Use TYPO3 v9 Core API (Environment API)
- use PHP7 methods for hook-array checks instead of is_array()
- Use !empty() instead of count() to avoid possible PHP 7.2 issues
- Intantiate TSFE properly, similar to as done in EXT:redirects
- Avoid "global $TYPO3_CONF_VARS" and "global $TCA"
- Proper return statements where requested by phpdoc
- Remove usage of LanguageService fallback ($LANG is always available if in BE/CLI context)

Closes: #425