### PR TITLE
[!!!][TASK] Remove logFile extension configuration setting

### DIFF
--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -1618,7 +1618,7 @@ class CrawlerController implements LoggerAwareInterface
             fclose($fp);
 
             $time = microtime(true) - $startTime;
-            $this->log($originalUrl . ' ' . $time);
+            $this->logger->info($originalUrl . ' ' . $time);
 
             // Implode content and headers:
             $result = [
@@ -1718,20 +1718,6 @@ class CrawlerController implements LoggerAwareInterface
         }
 
         return $response;
-    }
-
-    /**
-     * In the future this setting "logFileName" should be removed in favor of using the TYPO3 Logging Framework
-     * @param string the message string to log
-     */
-    protected function log(string $message): void
-    {
-        if (!empty($this->extensionSettings['logFileName'])) {
-            @file_put_contents($this->extensionSettings['logFileName'], date('Ymd His') . ' ' . $message . PHP_EOL, FILE_APPEND);
-        }
-        $this->logger->info(
-            sprintf('File "%s" could not be written, please check file permissions.', $this->extensionSettings['logFileName'])
-        );
     }
 
     /**
@@ -2528,7 +2514,7 @@ class CrawlerController implements LoggerAwareInterface
 
         $startTime = microtime(true);
         $content = $this->executeShellCommand($cmd);
-        $this->log($url . ' ' . (microtime(true) - $startTime));
+        $this->logger->info($url . ' ' . (microtime(true) - $startTime));
 
         $result = [
             'request' => implode("\r\n", $requestHeaders) . "\r\n\r\n",

--- a/Tests/Functional/Api/CrawlerApiTest.php
+++ b/Tests/Functional/Api/CrawlerApiTest.php
@@ -95,7 +95,6 @@ class CrawlerApiTest extends FunctionalTestCase
             'crawlHiddenPages' => '0',
             'phpPath' => '/usr/bin/php',
             'enableTimeslot' => '1',
-            'logFileName' => '',
             'follow30x' => '0',
             'makeDirectRequests' => '0',
             'frontendBasePath' => '/',

--- a/Tests/Functional/Domain/Repository/ProcessRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ProcessRepositoryTest.php
@@ -76,7 +76,6 @@ class ProcessRepositoryTest extends FunctionalTestCase
             'crawlHiddenPages' => '0',
             'phpPath' => '/usr/bin/php',
             'enableTimeslot' => '1',
-            'logFileName' => '',
             'follow30x' => '0',
             'makeDirectRequests' => '0',
             'frontendBasePath' => '/',

--- a/Tests/Unit/Controller/CrawlerControllerTest.php
+++ b/Tests/Unit/Controller/CrawlerControllerTest.php
@@ -70,7 +70,6 @@ class CrawlerControllerTest extends UnitTestCase
             'crawlHiddenPages' => '0',
             'phpPath' => '/usr/bin/php',
             'enableTimeslot' => '1',
-            'logFileName' => '',
             'follow30x' => '0',
             'makeDirectRequests' => '0',
             'frontendBasePath' => '/',

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -66,9 +66,6 @@ purgeQueueDays=14
 # cat=System; type=string; label= PHP Path: Local path to php binary file (e.g. "/usr/bin/php")
 phpPath=/usr/bin/php
 
-# cat=System; type=string; label= Log Filename:
-logFileName=
-
 #########
 ## Debug
 #########


### PR DESCRIPTION
The option "logFile" is not needed, as now the logger API
is taking care of logging into various channels.

Fixes: #435