### PR TITLE
[!!!][FEATURE] Automatically calculate cHash and Base URL via Site Handling

### DIFF
--- a/Configuration/TCA/tx_crawler_configuration.php
+++ b/Configuration/TCA/tx_crawler_configuration.php
@@ -18,7 +18,7 @@ return [
         ],
     ],
     'interface' => [
-        'showRecordFieldList' => 'hidden,name,force_ssl,processing_instruction_filter,processing_instruction_parameters_ts,configuration,base_url,pidsonly,begroups,chash, exclude'
+        'showRecordFieldList' => 'hidden,name,force_ssl,processing_instruction_filter,processing_instruction_parameters_ts,configuration,base_url,pidsonly,begroups,exclude'
     ],
     'columns' => [
         'hidden' => [
@@ -149,13 +149,6 @@ return [
                 'foreign_table' => 'fe_groups'
             ]
         ],
-        'chash' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:crawler/Resources/Private/Language/Backend.xlf:tx_crawler_configuration.chash',
-            'config' => [
-                'type' => 'check',
-            ]
-        ],
         'exclude' => [
             'exclude' => true,
             'label' => 'LLL:EXT:crawler/Resources/Private/Language/Backend.xlf:tx_crawler_configuration.exclude',
@@ -181,7 +174,7 @@ return [
         ]
     ],
     'types' => [
-        '0' => ['showitem' => 'hidden, name, force_ssl, processing_instruction_filter, base_url, sys_domain_base_url, root_template_pid, pidsonly, configuration, processing_instruction_parameters_ts,begroups, fegroups, chash, exclude']
+        '0' => ['showitem' => 'hidden, name, force_ssl, processing_instruction_filter, base_url, sys_domain_base_url, root_template_pid, pidsonly, configuration, processing_instruction_parameters_ts,begroups, fegroups, exclude']
     ],
     'palettes' => [
         '1' => ['showitem' => '']

--- a/Documentation/Configuration/ConfigurationRecords/Index.rst
+++ b/Documentation/Configuration/ConfigurationRecords/Index.rst
@@ -55,8 +55,6 @@ Fields and their pageTS equivalents
 
 - **Crawl with FE usergroups** - :ref:`paramSets.[key].userGroups <crawler-tsconfig-paramSets-key-userGroups>`
 
-- **Append cHash** - :ref:`paramSets.[key].cHash <crawler-tsconfig-paramSets-key-cHash>`
-
 - **Exclude pages** - comma separated list of page ids which should not be crawled
 
 .. image:: /Images/backend_configurationrecord.png

--- a/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
+++ b/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
@@ -105,7 +105,6 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
                myConfigurationKeyName = &tx_myext[items]=[_TABLE:tt_myext_items;_PID:15;_WHERE: and hidden = 0]
                myConfigurationKeyName {
                  pidsonly = 13
-                 chash = 1
                  procInstrFilter = tx_indexedsearch_reindex
                }
             }
@@ -179,22 +178,6 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
 
    Description
          User groups to set for the request.
-
-   Default
-
-
-.. container:: table-row
-
-   Property
-         .. _crawler-tsconfig-paramSets-key-cHash:
-
-         paramSets.[key].cHash
-
-   Data type
-         boolean
-
-   Description
-         If set, a cHash value is calculated and added to the URLs.
 
    Default
 

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -45,9 +45,6 @@
             <trans-unit id="tx_crawler_configuration.fegroups">
                 <source>Crawl with FE usergroups</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.chash">
-                <source>Append cHash</source>
-            </trans-unit>
             <trans-unit id="tx_crawler_configuration.exclude">
                 <source>Exclude pages</source>
             </trans-unit>

--- a/Tests/Functional/Fixtures/tx_crawler_configuration.xml
+++ b/Tests/Functional/Fixtures/tx_crawler_configuration.xml
@@ -15,7 +15,6 @@
         <pidsonly></pidsonly>
         <begroups></begroups>
         <fegroups></fegroups>
-        <chash>0</chash>
         <exclude>0</exclude>
         <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>
@@ -34,7 +33,6 @@
         <pidsonly></pidsonly>
         <begroups></begroups>
         <fegroups></fegroups>
-        <chash>0</chash>
         <exclude>0</exclude>
         <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>
@@ -53,7 +51,6 @@
         <pidsonly></pidsonly>
         <begroups></begroups>
         <fegroups></fegroups>
-        <chash>0</chash>
         <exclude>0</exclude>
         <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>
@@ -72,7 +69,6 @@
         <pidsonly></pidsonly>
         <begroups></begroups>
         <fegroups></fegroups>
-        <chash>0</chash>
         <exclude>0</exclude>
         <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>
@@ -91,7 +87,6 @@
         <pidsonly></pidsonly>
         <begroups></begroups>
         <fegroups></fegroups>
-        <chash>0</chash>
         <exclude>0</exclude>
         <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>

--- a/Tests/Functional/SiteBasedTestTrait.php
+++ b/Tests/Functional/SiteBasedTestTrait.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types = 1);
+namespace AOE\Crawler\Tests\Functional;
+
+/*
+ * This file is part of the EXT:crawler extension.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Configuration\SiteConfiguration;
+
+/**
+ * Trait used for test classes that want to set up (= write) site configuration files.
+ *
+ * Mainly used when testing Site-related tests in Frontend requests.
+ *
+ * Be sure to set the LANGUAGE_PRESETS const in your class.
+ */
+trait SiteBasedTestTrait
+{
+    /**
+     * @param string $identifier
+     * @param array $site
+     * @param array $languages
+     * @param array $errorHandling
+     */
+    protected function writeSiteConfiguration(
+        string $identifier,
+        array $site = [],
+        array $languages = [],
+        array $errorHandling = []
+    ) {
+        $configuration = $site;
+        if (!empty($languages)) {
+            $configuration['languages'] = $languages;
+        }
+        if (!empty($errorHandling)) {
+            $configuration['errorHandling'] = $errorHandling;
+        }
+
+        $siteConfiguration = new SiteConfiguration(
+            $this->getInstancePath() . '/typo3conf/sites/'
+        );
+
+        try {
+            $siteConfiguration->write($identifier, $configuration);
+        } catch (\Exception $exception) {
+            $this->markTestSkipped($exception->getMessage());
+        }
+    }
+
+    /**
+     * @param string $identifier
+     * @param array $overrides
+     */
+    protected function mergeSiteConfiguration(
+        string $identifier,
+        array $overrides
+    ) {
+        $siteConfiguration = new SiteConfiguration(
+            $this->getInstancePath() . '/typo3conf/sites/'
+        );
+        $configuration = $siteConfiguration->load($identifier);
+        $configuration = array_merge($configuration, $overrides);
+        try {
+            $siteConfiguration->write($identifier, $configuration);
+        } catch (\Exception $exception) {
+            $this->markTestSkipped($exception->getMessage());
+        }
+    }
+
+    /**
+     * @param int $rootPageId
+     * @param string $base
+     * @return array
+     */
+    protected function buildSiteConfiguration(
+        int $rootPageId,
+        string $base = ''
+    ): array {
+        return [
+            'rootPageId' => $rootPageId,
+            'base' => $base,
+        ];
+    }
+
+    /**
+     * @param string $identifier
+     * @param string $base
+     * @return array
+     */
+    protected function buildDefaultLanguageConfiguration(
+        string $identifier,
+        string $base
+    ): array {
+        $configuration = $this->buildLanguageConfiguration($identifier, $base);
+        $configuration['typo3Language'] = 'default';
+        $configuration['flag'] = 'global';
+        unset($configuration['fallbackType'], $configuration['fallbacks']);
+        return $configuration;
+    }
+
+    /**
+     * @param string $identifier
+     * @param string $base
+     * @param array $fallbackIdentifiers
+     * @param string $fallbackType
+     * @return array
+     */
+    protected function buildLanguageConfiguration(
+        string $identifier,
+        string $base,
+        array $fallbackIdentifiers = [],
+        string $fallbackType = null
+    ): array {
+        $preset = $this->resolveLanguagePreset($identifier);
+
+        $configuration = [
+            'languageId' => $preset['id'],
+            'title' => $preset['title'],
+            'navigationTitle' => $preset['title'],
+            'base' => $base,
+            'locale' => $preset['locale'],
+            'iso-639-1' => $preset['iso'],
+            'hreflang' => $preset['hrefLang'],
+            'direction' => $preset['direction'],
+            'typo3Language' => $preset['iso'],
+            'flag' => $preset['iso'],
+            'fallbackType' => $fallbackType ?? (empty($fallbackIdentifiers) ? 'strict' : 'fallback'),
+        ];
+
+        if (!empty($fallbackIdentifiers)) {
+            $fallbackIds = array_map(
+                function (string $fallbackIdentifier) {
+                    $preset = $this->resolveLanguagePreset($fallbackIdentifier);
+                    return $preset['id'];
+                },
+                $fallbackIdentifiers
+            );
+            $configuration['fallbackType'] = $fallbackType ?? 'fallback';
+            $configuration['fallbacks'] = implode(',', $fallbackIds);
+        }
+
+        return $configuration;
+    }
+
+    /**
+     * @param string $identifier
+     * @return mixed
+     */
+    protected function resolveLanguagePreset(string $identifier)
+    {
+        if (!isset(static::LANGUAGE_PRESETS[$identifier])) {
+            throw new \LogicException(
+                sprintf('Undefined preset identifier "%s"', $identifier),
+                1533893665
+            );
+        }
+        return static::LANGUAGE_PRESETS[$identifier];
+    }
+}

--- a/Tests/Functional/data/canCreateQueueEntriesUsingConfigurationRecord.xml
+++ b/Tests/Functional/data/canCreateQueueEntriesUsingConfigurationRecord.xml
@@ -2,7 +2,11 @@
 <dataset>
     <pages uid="7">
         <uid>7</uid>
+        <pid>0</pid>
+        <slug>/</slug>
         <TSconfig></TSconfig>
+        <sys_language_uid>0</sys_language_uid>
+        <l10n_parent>0</l10n_parent>
     </pages>
     <tx_crawler_configuration>
         <uid>7</uid>

--- a/Tests/Functional/data/pages.xml
+++ b/Tests/Functional/data/pages.xml
@@ -6,12 +6,18 @@
 		<title>Root</title>
 		<deleted>0</deleted>
 		<is_siteroot>1</is_siteroot>
+		<slug>/</slug>
+		<sys_language_uid>0</sys_language_uid>
+		<l10n_parent>0</l10n_parent>
 	</pages>
 	<pages>
 		<uid>2</uid>
 		<pid>1</pid>
 		<title>Archived</title>
 		<deleted>0</deleted>
+		<slug>/archived</slug>
 		<is_siteroot>0</is_siteroot>
+		<sys_language_uid>0</sys_language_uid>
+		<l10n_parent>0</l10n_parent>
 	</pages>
 </dataset>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -63,7 +63,6 @@ CREATE TABLE tx_crawler_configuration (
   pidsonly blob,
   begroups varchar(100) DEFAULT '0' NOT NULL,
   fegroups varchar(100) DEFAULT '0' NOT NULL,
-  chash tinyint(4) DEFAULT '0' NOT NULL,
   exclude text NOT NULL,
   root_template_pid int(11) DEFAULT '0' NOT NULL,
 


### PR DESCRIPTION
When using Site Handling in TYPO3 v9, pages with a site component now receive a baseUrl from the current site where the page is located on.

Using Site Handling's PageRouter functionality, the cHash is then automatically added when needed.

In addition to that, when having no site configuration (which is only the case when dealing with RealURL v9 forks) the cHash is then automatically calculated.

For this case, the option "tx_crawler_configuration.cHash" is removed without substitution, to follow TYPO3 Core's pattern to have TYPO3 Core deal with cHash generation then.