### PR TITLE
[!!!][TASK] Remove root_template_pid option

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -66,11 +66,6 @@ class Configuration extends AbstractEntity
     /**
      * @var string
      */
-    protected $sysDomainBaseUrl = '';
-
-    /**
-     * @var string
-     */
     protected $pidsonly = '';
 
     /**
@@ -84,24 +79,9 @@ class Configuration extends AbstractEntity
     protected $fegroups = '';
 
     /**
-     * @var int
-     */
-    protected $realurl = 0;
-
-    /**
-     * @var int
-     */
-    protected $chash = 0;
-
-    /**
      * @var string
      */
     protected $exclude = '';
-
-    /**
-     * @var int
-     */
-    protected $rootTemplatePid = 0;
 
     /**
      * @return string
@@ -200,22 +180,6 @@ class Configuration extends AbstractEntity
     }
 
     /**
-     * @return string
-     */
-    public function getSysDomainBaseUrl()
-    {
-        return $this->sysDomainBaseUrl;
-    }
-
-    /**
-     * @param string $sysDomainBaseUrl
-     */
-    public function setSysDomainBaseUrl($sysDomainBaseUrl)
-    {
-        $this->sysDomainBaseUrl = $sysDomainBaseUrl;
-    }
-
-    /**
      * @return mixed
      */
     public function getPidsOnly()
@@ -264,38 +228,6 @@ class Configuration extends AbstractEntity
     }
 
     /**
-     * @return int
-     */
-    public function getRealUrl()
-    {
-        return $this->realurl;
-    }
-
-    /**
-     * @param int $realUrl
-     */
-    public function setRealUrl($realUrl)
-    {
-        $this->realurl = $realUrl;
-    }
-
-    /**
-     * @return int
-     */
-    public function getCHash()
-    {
-        return $this->chash;
-    }
-
-    /**
-     * @param int $cHash
-     */
-    public function setCHash($cHash)
-    {
-        $this->chash = $cHash;
-    }
-
-    /**
      * @return string
      */
     public function getExclude()
@@ -309,22 +241,6 @@ class Configuration extends AbstractEntity
     public function setExclude($exclude)
     {
         $this->exclude = $exclude;
-    }
-
-    /**
-     * @return int
-     */
-    public function getRootTemplatePid()
-    {
-        return $this->rootTemplatePid;
-    }
-
-    /**
-     * @param int $rootTemplatePid
-     */
-    public function setRootTemplatePid($rootTemplatePid)
-    {
-        $this->rootTemplatePid = $rootTemplatePid;
     }
 }
 

--- a/Classes/Utility/BackendUtility.php
+++ b/Classes/Utility/BackendUtility.php
@@ -54,19 +54,6 @@ class BackendUtility
     }
 
     /**
-     * Registers the context sensitive help for TCA fields
-     *
-     * @return void
-     */
-    public static function registerContextSensitiveHelpForTcaFields()
-    {
-        ExtensionManagementUtility::addLLrefForTCAdescr(
-            'tx_crawler_configuration',
-            'EXT:crawler/Resources/Private/Language/locallang_csh_tx_crawler_configuration.xlf'
-        );
-    }
-
-    /**
      * Registers icons for use in the IconFactory
      *
      * @return void

--- a/Configuration/TCA/tx_crawler_configuration.php
+++ b/Configuration/TCA/tx_crawler_configuration.php
@@ -140,24 +140,10 @@ return [
                 'cols' => 48,
                 'rows' => 3,
             ]
-        ],
-        'root_template_pid' => [
-            'exclude' => true,
-            'label' => 'LLL:EXT:crawler/Resources/Private/Language/Backend.xlf:tx_crawler_configuration.root_template_pid',
-            'config' => [
-                'type' => 'group',
-                'internal_type' => 'db',
-                'allowed' => 'pages',
-                'size' => 1,
-                'maxitems' => 1,
-                'minitems' => 0,
-                'show_thumbs' => 1,
-                'default' => 0
-            ]
         ]
     ],
     'types' => [
-        '0' => ['showitem' => 'hidden, name, force_ssl, processing_instruction_filter, base_url, root_template_pid, pidsonly, configuration, processing_instruction_parameters_ts,begroups, fegroups, exclude']
+        '0' => ['showitem' => 'hidden, name, force_ssl, processing_instruction_filter, base_url, pidsonly, configuration, processing_instruction_parameters_ts,begroups, fegroups, exclude']
     ],
     'palettes' => [
         '1' => ['showitem' => '']

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -48,10 +48,6 @@
             <trans-unit id="tx_crawler_configuration.exclude">
                 <source>Exclude pages</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.root_template_pid">
-                <source>Page Id of TypoScript root template</source>
-            </trans-unit>
-
             <trans-unit id="crawler_im.name">
                 <source>Crawler queue</source>
             </trans-unit>

--- a/Tests/Functional/Api/CrawlerApiTest.php
+++ b/Tests/Functional/Api/CrawlerApiTest.php
@@ -339,8 +339,7 @@ class CrawlerApiTest extends FunctionalTestCase
                 'tx_staticpub_publish.' => [
                     'includeResources' => 'relPath'
                 ]
-            ],
-            'rootTemplatePid' => 1
+            ]
         ];
         $expectedParameter = serialize($expectedParameterData);
 

--- a/Tests/Functional/Fixtures/tx_crawler_configuration.xml
+++ b/Tests/Functional/Fixtures/tx_crawler_configuration.xml
@@ -15,7 +15,6 @@
         <begroups></begroups>
         <fegroups></fegroups>
         <exclude>0</exclude>
-        <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>
     <tx_crawler_configuration>
         <uid>2</uid>
@@ -32,7 +31,6 @@
         <begroups></begroups>
         <fegroups></fegroups>
         <exclude>0</exclude>
-        <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>
     <tx_crawler_configuration>
         <uid>3</uid>
@@ -49,7 +47,6 @@
         <begroups></begroups>
         <fegroups></fegroups>
         <exclude>0</exclude>
-        <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>
     <tx_crawler_configuration>
         <uid>4</uid>
@@ -66,7 +63,6 @@
         <begroups></begroups>
         <fegroups></fegroups>
         <exclude>0</exclude>
-        <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>
     <tx_crawler_configuration>
         <uid>5</uid>
@@ -83,6 +79,5 @@
         <begroups></begroups>
         <fegroups></fegroups>
         <exclude>0</exclude>
-        <root_template_pid>0</root_template_pid>
     </tx_crawler_configuration>
 </dataset>

--- a/Tests/Functional/data/canCreateQueueEntriesUsingConfigurationRecord.xml
+++ b/Tests/Functional/data/canCreateQueueEntriesUsingConfigurationRecord.xml
@@ -23,6 +23,5 @@
         <base_url>http://www.testcase.de/</base_url>
         <pidsonly></pidsonly>
         <exclude></exclude>
-        <root_template_pid>1</root_template_pid>
     </tx_crawler_configuration>
 </dataset>

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,6 +3,5 @@ defined('TYPO3_MODE') or die();
 
 if ('BE' === TYPO3_MODE) {
     \AOE\Crawler\Utility\BackendUtility::registerInfoModuleFunction();
-    \AOE\Crawler\Utility\BackendUtility::registerContextSensitiveHelpForTcaFields();
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_crawler_configuration');
 }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -63,7 +63,6 @@ CREATE TABLE tx_crawler_configuration (
   begroups varchar(100) DEFAULT '0' NOT NULL,
   fegroups varchar(100) DEFAULT '0' NOT NULL,
   exclude text NOT NULL,
-  root_template_pid int(11) DEFAULT '0' NOT NULL,
 
   PRIMARY KEY (uid),
   KEY parent (pid)


### PR DESCRIPTION
Evaluating TSFE and the sys_template record is not needed anymore,
as Frontend requests are called externally (Direct via SubRequest or via Guzzle),
so this option can be removed without substitution.

Along with the change the Configuration Model class is cleaned up with
only the properties needed.