### PR TITLE
Refactor check for php executable

### DIFF
--- a/Classes/Backend/BackendModule.php
+++ b/Classes/Backend/BackendModule.php
@@ -869,14 +869,7 @@ class BackendModule
             $this->addErrorMessage($this->getLanguageService()->sL('LLL:EXT:crawler/Resources/Private/Language/locallang.xml:message.noPhpForkAvailable'));
         }
 
-        $exitCode = 0;
-        $out = [];
-        CommandUtility::exec(
-            CommandUtility::escapeShellArgument($this->extensionSettings['phpPath'] . ' -v'),
-            $out,
-            $exitCode
-        );
-        if ($exitCode > 0) {
+        if (!CommandUtility::checkCommand($this->extensionSettings['phpPath'])) {
             $this->addErrorMessage(sprintf($this->getLanguageService()->sL('LLL:EXT:crawler/Resources/Private/Language/locallang.xml:message.phpBinaryNotFound'), htmlspecialchars($this->extensionSettings['phpPath'])));
         }
     }

--- a/Classes/Service/ProcessService.php
+++ b/Classes/Service/ProcessService.php
@@ -200,9 +200,9 @@ class ProcessService
 
         // Check whether OS is Windows
         if (Environment::isWindows()) {
-            $completePath = CommandUtility::escapeShellArgument('start ' . $this->getCrawlerCliPath());
+            $completePath = 'start ' . $this->getCrawlerCliPath();
         } else {
-            $completePath = '(' . CommandUtility::escapeShellArgument($this->getCrawlerCliPath()) . ' &) > /dev/null';
+            $completePath = '(' . $this->getCrawlerCliPath() . ' &) > /dev/null';
         }
 
         $fileHandler = CommandUtility::exec($completePath);


### PR DESCRIPTION
CommandUtility delivers possibility to check for an executable command, so let's use this one. By the way the current code fails due to wrong use of CommandUtility::escapeShellArgument for escaping the command not the arguments.