### PR TITLE
[FEATURE] add _RECURSIVE option to the subpartParams Configuration of the lookup _TABLE instructions (#479)

### DIFF
--- a/CONTRIBUTERS.md
+++ b/CONTRIBUTERS.md
@@ -8,6 +8,7 @@ Thanks for helping out.
 PS: Please add in alphabetical order.
 
 * Benni Mack <benni@typo3.org>
+* Sebastian Mazza <sebastian@mazza.at>
 * Tizian Schmidlin <tizian.schmidlin@gmail.com>
 * Tobias Stahn <hello@tstahn.io>
 * Tomas Norre Mikkelsen <tomasnorre@gmail.com>

--- a/Classes/Api/CrawlerApi.php
+++ b/Classes/Api/CrawlerApi.php
@@ -289,7 +289,7 @@ class CrawlerApi
             $res = 0;
         }
 
-        return $res;
+        return intval($res);
     }
 
     /**

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -128,12 +128,7 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
             $crawlerController->registerQueueEntriesInternallyOnly = true;
         }
 
-        #if ($this->request instanceof \TYPO3\CMS\Extbase\Mvc\Cli\Request) {
-            $pageId = MathUtility::forceIntegerInRange($input->getOption('page'), 0);
-        #} else {
-            // Crawler is called over Backend
-        #    $pageId = 1;
-        #}
+        $pageId = MathUtility::forceIntegerInRange($input->getOption('page'), 0);
 
         $configurationKeys = $this->getConfigurationKeys($input->getOption('conf'));
 

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -128,12 +128,12 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
             $crawlerController->registerQueueEntriesInternallyOnly = true;
         }
 
-        if ($this->request instanceof \TYPO3\CMS\Extbase\Mvc\Cli\Request) {
-            $pageId = MathUtility::forceIntegerInRange($input->getOption('startpage'), 0);
-        } else {
+        #if ($this->request instanceof \TYPO3\CMS\Extbase\Mvc\Cli\Request) {
+            $pageId = MathUtility::forceIntegerInRange($input->getOption('page'), 0);
+        #} else {
             // Crawler is called over Backend
-            $pageId = 1;
-        }
+        #    $pageId = 1;
+        #}
 
         $configurationKeys = $this->getConfigurationKeys($input->getOption('conf'));
 

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -817,18 +817,20 @@ class CrawlerController implements LoggerAwareInterface
                                 $queryBuilder
                                     ->select($fieldName)
                                     ->from($subpartParams['_TABLE'])
-                                    // TODO: Check if this works as intended!
-                                    ->add('from', $addTable)
                                     ->where(
-                                        $queryBuilder->expr()->eq($queryBuilder->quoteIdentifier($pidField), $queryBuilder->createNamedParameter($lookUpPid, \PDO::PARAM_INT)),
+                                        $queryBuilder->expr()->eq($pidField, $queryBuilder->createNamedParameter($lookUpPid, \PDO::PARAM_INT)),
                                         $where
                                     );
+                                if(!empty($addTable)) {
+                                    // TODO: Check if this works as intended!
+                                    $queryBuilder->add('from', $addTable);
+                                }
                                 $transOrigPointerField = $GLOBALS['TCA'][$subpartParams['_TABLE']]['ctrl']['transOrigPointerField'];
 
                                 if ($subpartParams['_ENABLELANG'] && $transOrigPointerField) {
                                     $queryBuilder->andWhere(
                                         $queryBuilder->expr()->lte(
-                                            $queryBuilder->quoteIdentifier($transOrigPointerField),
+                                           $transOrigPointerField,
                                             0
                                         )
                                     );
@@ -838,7 +840,7 @@ class CrawlerController implements LoggerAwareInterface
 
                                 $rows = [];
                                 while ($row = $statement->fetch()) {
-                                    $rows[$fieldName] = $row;
+                                    $rows[$row[$fieldName]] = $row;
                                 }
 
                                 if (is_array($rows)) {

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -666,7 +666,7 @@ class CrawlerController implements LoggerAwareInterface
      * @param $depth
      * @return array
      *
-     * TODO: Write Functional Tests => done?!?!
+     * TODO: Write Functional Tests
      */
     public function getConfigurationsForBranch(int $rootid, $depth)
     {
@@ -694,14 +694,6 @@ class CrawlerController implements LoggerAwareInterface
         }
 
         $queryBuilder = $this->getQueryBuilder('tx_crawler_configuration');
-
-        // The pre TYPO3 v9 version use the method BackendUtility::BEenableFields('tx_crawler_configuration') 
-        // to create the where clause (deleted, hidden, startTime, endTime ), this is exactly the new default behavior 
-        // Therefore, why remove the default restrictions for TYPO3 v9?
-        #$queryBuilder->getRestrictions()
-        #    ->removeAll() 
-        #    ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-
         $statement = $queryBuilder
             ->select('name')
             ->from('tx_crawler_configuration')
@@ -852,7 +844,7 @@ class CrawlerController implements LoggerAwareInterface
                                 if ($subpartParams['_ENABLELANG'] && $transOrigPointerField) {
                                     $queryBuilder->andWhere(
                                         $queryBuilder->expr()->lte(
-                                           $transOrigPointerField,
+                                            $transOrigPointerField,
                                             0
                                         )
                                     );
@@ -1214,8 +1206,6 @@ class CrawlerController implements LoggerAwareInterface
      * @param array $fieldArray
      *
      * @return array
-     *
-     * TODO: Write Functional Tests => done?!?!
      */
     protected function getDuplicateRowsIfExist($tstamp, $fieldArray)
     {
@@ -1254,8 +1244,8 @@ class CrawlerController implements LoggerAwareInterface
         }
 
         $queryBuilder
-            /* ->andWhere('exec_time != 0') # this was ' AND NOT exec_time' therfore functional test fails => change back */ ->andWhere('NOT exec_time')
-            /* ->andWhere('process_id != 0') # this was ' AND NOT process_id' therfore functional test fails => change back */ ->andWhere('NOT process_id')
+            ->andWhere('NOT exec_time')
+            ->andWhere('NOT process_id')
             ->andWhere($queryBuilder->expr()->eq('page_id', $queryBuilder->createNamedParameter($fieldArray['page_id'], \PDO::PARAM_INT)))
             ->andWhere($queryBuilder->expr()->eq('parameters_hash', $queryBuilder->createNamedParameter($fieldArray['parameters_hash'], \PDO::PARAM_STR)))
             ;

--- a/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
+++ b/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
@@ -102,7 +102,7 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
          ::
 
             tx_crawler.crawlerCfg.paramSets {
-               myConfigurationKeyName = &tx_myext[items]=[_TABLE:tt_myext_items;_PID:15;_WHERE: and hidden = 0]
+               myConfigurationKeyName = &tx_myext[items]=[_TABLE:tt_myext_items;_PID:15;_WHERE: hidden = 0]
                myConfigurationKeyName {
                  pidsonly = 13
                  procInstrFilter = tx_indexedsearch_reindex

--- a/Documentation/ExecutingTheQueue/RunningViaCommandController/Index.rst
+++ b/Documentation/ExecutingTheQueue/RunningViaCommandController/Index.rst
@@ -10,7 +10,7 @@ Create queue
 ::
 
    # replace vendor/bin/typo3 with your own cli runner
-   $ vendor/bin/typo3 crawler:buildqueue [--startpage <page-id>] [--depth <depth>] [--conf <configurationKey1,configurationKey2,...>] [--number <number>] [--mode <exec|queue|url>]
+   $ vendor/bin/typo3 crawler:buildqueue [--page <page-id>] [--depth <depth>] [--conf <configurationKey1,configurationKey2,...>] [--number <number>] [--mode <exec|queue|url>]
 
 Run queue
 ---------

--- a/Tests/Functional/Api/CrawlerApiTest.php
+++ b/Tests/Functional/Api/CrawlerApiTest.php
@@ -4,7 +4,7 @@ namespace AOE\Crawler\Tests\Functional\Api;
 /***************************************************************
  *  Copyright notice
  *
- *  (c) 2018 AOE GmbH <dev@aoe.com>
+ *  (c) 2019 AOE GmbH <dev@aoe.com>
  *
  *  All rights reserved
  *
@@ -240,10 +240,10 @@ class CrawlerApiTest extends FunctionalTestCase
     {
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_crawler_queue.xml');
 
-        self::assertSame(
+        $this->assertEquals(
             [
                 'assignedButUnprocessed' => 3,
-                'unprocessed' => 5
+                'unprocessed' => 7
             ],
             $this->subject->getQueueStatistics()
         );

--- a/Tests/Functional/Controller/CrawlerControllerTest.php
+++ b/Tests/Functional/Controller/CrawlerControllerTest.php
@@ -62,7 +62,6 @@ class CrawlerControllerTest extends FunctionalTestCase
     {
         parent::setUp();
         $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        #$this->importDataSet(__DIR__ . '/../Fixtures/sys_domain.xml');
         $this->importDataSet(__DIR__ . '/../Fixtures/pages.xml');
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_crawler_configuration.xml');
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_crawler_queue.xml');
@@ -218,19 +217,6 @@ class CrawlerControllerTest extends FunctionalTestCase
         );
     }
 
-// CrawlerController::isCrawlingProtocolHttps() removed in [7f7f07b]
-    /**
-     * @test
-     * @dataProvider isCrawlingProtocolHttpsDataProvider
-     */
-//    public function isCrawlingProtocolHttps($crawlerConfiguration, $pageConfiguration, $expected)
-//    {
-//        $this->assertEquals(
-//            $expected,
-//            $this->subject->_call(isCrawlingProtocolHttps, $crawlerConfiguration, $pageConfiguration)
-//        );
-//    }
-    
     /**
      * @test
      */
@@ -690,33 +676,4 @@ class CrawlerControllerTest extends FunctionalTestCase
         ];
     }
 
-// CrawlerController::isCrawlingProtocolHttps() removed in [7f7f07b]
-    /**
-     * @return array
-     */
-//    public function isCrawlingProtocolHttpsDataProvider()
-//    {
-//        return [
-//            'Crawler Configuration set to http' => [
-//                'crawlerConfiguration' => -1,
-//                'pageConfiguration' => true,
-//                'expected' => false,
-//            ],
-//            'Crawler Configuration set to https' => [
-//                'crawlerConfiguration' => 1,
-//                'pageConfiguration' => false,
-//                'expected' => true,
-//            ],
-//            'Crawler Configuration set to page-configuration' => [
-//                'crawlerConfiguration' => 0,
-//                'pageConfiguration' => true,
-//                'expected' => true,
-//            ],
-//            'Crawler Configuration default fallback' => [
-//                'crawlerConfiguration' => 99,
-//                'pageConfiguration' => true,
-//                'expected' => false,
-//            ],
-//        ];
-//    }
 }

--- a/Tests/Functional/Controller/CrawlerControllerTest.php
+++ b/Tests/Functional/Controller/CrawlerControllerTest.php
@@ -67,6 +67,7 @@ class CrawlerControllerTest extends FunctionalTestCase
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_crawler_configuration.xml');
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_crawler_queue.xml');
         $this->importDataSet(__DIR__ . '/../Fixtures/tx_crawler_process.xml');
+        $this->importDataSet(__DIR__ . '/../Fixtures/tt_content.xml');
         $this->subject = $this->getAccessibleMock(CrawlerController::class, ['dummy']);
     }
 
@@ -346,7 +347,28 @@ class CrawlerControllerTest extends FunctionalTestCase
                 'expected' => [
                     'table' => [2,3,4,5]
                 ]
-            ]
+            ],
+            'Parameters with _TABLE _PID _RECURSIVE(:0) & _WHERE (hidden = 0)' => [
+                'paramArray' => ['table' => '[_TABLE:tt_content;_PID:5;_RECURSIVE:0;_WHERE: hidden = 0]'],
+                'pid' => 1,
+                'expected' => [
+                    'table' => [1,2]
+                ]
+            ],
+            'Parameters with _TABLE _PID _RECURSIVE(:1) & _WHERE (hidden = 0)' => [
+                'paramArray' => ['table' => '[_TABLE:tt_content;_PID:5;_RECURSIVE:1;_WHERE: hidden = 0]'],
+                'pid' => 1,
+                'expected' => [
+                    'table' => [1,2,3]
+                ]
+            ],
+            'Parameters with _TABLE _PID _RECURSIVE(:2) & _WHERE (hidden = 0)' => [
+                'paramArray' => ['table' => '[_TABLE:tt_content;_PID:5;_RECURSIVE:2;_WHERE: hidden = 0]'],
+                'pid' => 1,
+                'expected' => [
+                    'table' => [1,2,3,5,6]
+                ]
+            ],
         ];
     }
 

--- a/Tests/Functional/Controller/CrawlerControllerTest.php
+++ b/Tests/Functional/Controller/CrawlerControllerTest.php
@@ -302,6 +302,54 @@ class CrawlerControllerTest extends FunctionalTestCase
         );
     }
 
+    /**
+     * @test
+     * @dataProvider expandParametersDataProvider
+     */
+    public function expandParameters($paramArray, $pid, $expected)
+    {
+        $output = $this->subject->expandParameters($paramArray, $pid);
+
+        $this->assertEquals(
+            $expected,
+            $output
+        );
+    }
+
+    public function expandParametersDataProvider()
+    {
+        return [
+            'Parameters with range' => [
+                'paramArray' => ['range' => '[1-5]'],
+                'pid' => 1,
+                'expected' => [
+                    'range' => [1,2,3,4,5]
+                ]
+            ],
+            'Parameters with _TABLE _PID & _WHERE (hidden = 0)'=> [
+                'paramArray' => ['table' => '[_TABLE:pages;_PID:5;_WHERE: hidden = 0]'],
+                'pid' => 1,
+                'expected' => [
+                    'table' => [7]
+                ]
+            ],
+            'Parameters with _TABLE _PID & _WHERE (hidden = 1)' => [
+                'paramArray' => ['table' => '[_TABLE:pages;_PID:5:_WHERE: hidden = 1]'],
+                'pid' => 1,
+                'expected' => [
+                    'table' => [7,8]
+                ]
+            ],
+            'Parameters with _TABLE no _PID, then pid from input is used' => [
+                'paramArray' => ['table' => '[_TABLE:pages]'],
+                'pid' => 1,
+                'expected' => [
+                    'table' => [2,3,4,5]
+                ]
+            ]
+        ];
+    }
+
     public function addUrlDataProvider()
     {
         return [

--- a/Tests/Functional/Domain/Repository/ConfigurationRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ConfigurationRepositoryTest.php
@@ -67,7 +67,7 @@ class ConfigurationRepositoryTest extends FunctionalTestCase
     public function getCrawlerConfigurationRecords()
     {
         self::assertSame(
-            2,
+            3,
             count($this->subject->getCrawlerConfigurationRecords())
         );
     }

--- a/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
@@ -176,7 +176,7 @@ class QueueRepositoryTest extends FunctionalTestCase
     public function countUnprocessedItems()
     {
         self::assertEquals(
-            5,
+            7,
             $this->subject->countUnprocessedItems()
         );
     }
@@ -187,7 +187,7 @@ class QueueRepositoryTest extends FunctionalTestCase
     public function countAllPendingItems()
     {
         self::assertEquals(
-            5,
+            7,
             $this->subject->countAllPendingItems()
         );
     }
@@ -209,7 +209,7 @@ class QueueRepositoryTest extends FunctionalTestCase
     public function countAllUnassignedPendingItems()
     {
         self::assertEquals(
-            2,
+            4,
             $this->subject->countAllUnassignedPendingItems()
         );
     }
@@ -227,7 +227,7 @@ class QueueRepositoryTest extends FunctionalTestCase
             ],
             1 => [
                 'configuration' => 'SecondConfiguration',
-                'unprocessed' => 1,
+                'unprocessed' => 3,
                 'assignedButUnprocessed' => 1,
             ],
             2 => [
@@ -353,7 +353,7 @@ class QueueRepositoryTest extends FunctionalTestCase
     public function countAll()
     {
         self::assertEquals(
-            12,
+            14,
             $this->subject->countAll()
         );
     }

--- a/Tests/Functional/Fixtures/pages.xml
+++ b/Tests/Functional/Fixtures/pages.xml
@@ -63,4 +63,14 @@
 		<sys_language_uid>0</sys_language_uid>
 		<l10n_parent>0</l10n_parent>
 	</pages>
+	<pages>
+		<uid>8</uid>
+		<pid>5</pid>
+		<title>Page Uid 8</title>
+		<is_siteroot>0</is_siteroot>
+		<hidden>1</hidden>
+		<slug>/page-uid-5/page-uid-8</slug>
+		<sys_language_uid>0</sys_language_uid>
+		<l10n_parent>0</l10n_parent>
+	</pages>
 </dataset>

--- a/Tests/Functional/Fixtures/pages.xml
+++ b/Tests/Functional/Fixtures/pages.xml
@@ -3,7 +3,7 @@
 	<pages>
 		<uid>1</uid>
 		<pid>0</pid>
-		<title>Page Uid 1</title>
+		<title>Page 1 - Uid 1</title>
 		<is_siteroot>1</is_siteroot>
 		<slug>/</slug>
 		<sys_language_uid>0</sys_language_uid>
@@ -12,7 +12,7 @@
 	<pages>
 		<uid>2</uid>
 		<pid>1</pid>
-		<title>Page Uid 2</title>
+		<title>Page 1.2 - Uid 2</title>
 		<is_siteroot>0</is_siteroot>
 		<slug>/page-uid-2</slug>
 		<sys_language_uid>0</sys_language_uid>
@@ -21,7 +21,7 @@
 	<pages>
 		<uid>3</uid>
 		<pid>1</pid>
-		<title>Page Uid 3</title>
+		<title>Page 1.3 - Uid 3</title>
 		<is_siteroot>0</is_siteroot>
 		<slug>/page-uid-3</slug>
 		<sys_language_uid>0</sys_language_uid>
@@ -30,7 +30,7 @@
 	<pages>
 		<uid>4</uid>
 		<pid>1</pid>
-		<title>Page Uid 4</title>
+		<title>Page 1.4 - Uid 4</title>
 		<is_siteroot>0</is_siteroot>
 		<slug>/page-uid-4</slug>
 		<sys_language_uid>0</sys_language_uid>
@@ -39,7 +39,7 @@
 	<pages>
 		<uid>5</uid>
 		<pid>1</pid>
-		<title>Page Uid 5</title>
+		<title>Page 1.5 - Uid 5</title>
 		<is_siteroot>0</is_siteroot>
 		<slug>/page-uid-5</slug>
 		<sys_language_uid>0</sys_language_uid>
@@ -48,7 +48,7 @@
 	<pages>
 		<uid>7</uid>
 		<pid>5</pid>
-		<title>Page Uid 7</title>
+		<title>Page 1.5.7 - Uid 7</title>
 		<is_siteroot>0</is_siteroot>
 		<slug>/page-uid-5/page-uid-7</slug>
 		<sys_language_uid>0</sys_language_uid>
@@ -57,7 +57,7 @@
 	<pages>
 		<uid>6</uid>
 		<pid>3</pid>
-		<title>Page Uid 6</title>
+		<title>Page 1.3.6 - Uid 6</title>
 		<is_siteroot>0</is_siteroot>
 		<slug>/page-uid-3/page-uid-6</slug>
 		<sys_language_uid>0</sys_language_uid>
@@ -66,10 +66,28 @@
 	<pages>
 		<uid>8</uid>
 		<pid>5</pid>
-		<title>Page Uid 8</title>
+		<title>Page 1.5.8 - Uid 8</title>
 		<is_siteroot>0</is_siteroot>
 		<hidden>1</hidden>
 		<slug>/page-uid-5/page-uid-8</slug>
+		<sys_language_uid>0</sys_language_uid>
+		<l10n_parent>0</l10n_parent>
+	</pages>
+	<pages>
+		<uid>9</uid>
+		<pid>7</pid>
+		<title>Page 1.5.7.9 - Uid 9</title>
+		<is_siteroot>0</is_siteroot>
+		<slug>/page-uid-5/page-uid-7/page-uid-9</slug>
+		<sys_language_uid>0</sys_language_uid>
+		<l10n_parent>0</l10n_parent>
+	</pages>
+	<pages>
+		<uid>10</uid>
+		<pid>7</pid>
+		<title>Page 1.5.7.10 - Uid 10</title>
+		<is_siteroot>0</is_siteroot>
+		<slug>/page-uid-5/page-uid-7/page-uid-10</slug>
 		<sys_language_uid>0</sys_language_uid>
 		<l10n_parent>0</l10n_parent>
 	</pages>

--- a/Tests/Functional/Fixtures/tt_content.xml
+++ b/Tests/Functional/Fixtures/tt_content.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<tt_content>
+		<uid>1</uid>
+		<pid>5</pid>
+		<header>Record on page 1.5 - Uid 1</header>
+		<hidden>0</hidden>
+	</tt_content>
+	<tt_content>
+		<uid>2</uid>
+		<pid>5</pid>
+		<header>Record on page 1.5 - Uid 2</header>
+		<hidden>0</hidden>
+	</tt_content>
+	<tt_content>
+		<uid>3</uid>
+		<pid>7</pid>
+		<header>Record on page 1.5.7 - Uid 3</header>
+		<hidden>0</hidden>
+	</tt_content>
+	<tt_content>
+		<uid>4</uid>
+		<pid>7</pid>
+		<header>Record on page 1.5.7 - Uid 4</header>
+		<hidden>1</hidden>
+	</tt_content>
+	<tt_content>
+		<uid>5</uid>
+		<pid>9</pid>
+		<header>Record on page 1.5.7.9 - Uid 5</header>
+		<hidden>0</hidden>
+	</tt_content>
+	<tt_content>
+		<uid>6</uid>
+		<pid>10</pid>
+		<header>Record on page 1.5.7.10 - Uid 6</header>
+		<hidden>0</hidden>
+	</tt_content>
+</dataset>

--- a/Tests/Functional/Fixtures/tx_crawler_configuration.xml
+++ b/Tests/Functional/Fixtures/tx_crawler_configuration.xml
@@ -66,10 +66,42 @@
     </tx_crawler_configuration>
     <tx_crawler_configuration>
         <uid>5</uid>
-        <pid>0</pid>
+        <pid>5</pid>
         <deleted>0</deleted>
         <hidden>0</hidden>
-        <name>Not hidden or deleted</name>
+        <name>Not hidden or deleted - uid 5</name>
+        <force_ssl>1</force_ssl>
+        <processing_instruction_filter></processing_instruction_filter>
+        <processing_instruction_parameters_ts></processing_instruction_parameters_ts>
+        <configuration></configuration>
+        <base_url></base_url>
+        <pidsonly></pidsonly>
+        <begroups></begroups>
+        <fegroups></fegroups>
+        <exclude>0</exclude>
+    </tx_crawler_configuration>
+    <tx_crawler_configuration>
+        <uid>6</uid>
+        <pid>5</pid>
+        <deleted>0</deleted>
+        <hidden>0</hidden>
+        <name>Not hidden or deleted - uid 6</name>
+        <force_ssl>1</force_ssl>
+        <processing_instruction_filter></processing_instruction_filter>
+        <processing_instruction_parameters_ts></processing_instruction_parameters_ts>
+        <configuration></configuration>
+        <base_url></base_url>
+        <pidsonly></pidsonly>
+        <begroups></begroups>
+        <fegroups></fegroups>
+        <exclude>0</exclude>
+    </tx_crawler_configuration>
+    <tx_crawler_configuration>
+        <uid>7</uid>
+        <pid>5</pid>
+        <deleted>0</deleted>
+        <hidden>1</hidden>
+        <name>hidden or deleted - uid 7</name>
         <force_ssl>1</force_ssl>
         <processing_instruction_filter></processing_instruction_filter>
         <processing_instruction_parameters_ts></processing_instruction_parameters_ts>

--- a/Tests/Functional/Fixtures/tx_crawler_queue.xml
+++ b/Tests/Functional/Fixtures/tx_crawler_queue.xml
@@ -104,7 +104,7 @@
         <parameters></parameters>
         <result_data></result_data>
         <exec_time>0</exec_time>
-        <scheduled>0</scheduled>
+        <scheduled>12</scheduled>
         <configuration>FirstConfiguration</configuration>
     </tx_crawler_queue>
     <tx_crawler_queue>
@@ -128,5 +128,28 @@
         <exec_time>20</exec_time>
         <scheduled>4321</scheduled>
         <configuration>FirstConfiguration</configuration>
+    </tx_crawler_queue>
+    <tx_crawler_queue>
+        <qid>18</qid>
+        <page_id>15</page_id>
+        <process_id></process_id>
+        <process_id_completed>dvorak</process_id_completed>
+        <parameters></parameters>
+        <result_data></result_data>
+        <exec_time>0</exec_time>
+        <scheduled>0</scheduled>
+        <configuration>SecondConfiguration</configuration>
+    </tx_crawler_queue>
+    <tx_crawler_queue>
+        <qid>19</qid>
+        <page_id>15</page_id>
+        <process_id></process_id>
+        <process_id_completed>dvorak</process_id_completed>
+        <parameters></parameters>
+        <parameters_hash>NotReallyAHashButWillDoForTesting</parameters_hash>
+        <result_data></result_data>
+        <exec_time>0</exec_time>
+        <scheduled>12</scheduled>
+        <configuration>SecondConfiguration</configuration>
     </tx_crawler_queue>
 </dataset>


### PR DESCRIPTION
Applying my patch [eef0c94] to the typo3v9 branch was easy. Fixing some bugs that prevented me from testing the new table based parameter expansion and applying 2 change sets (18.07.19 [98605ee], 22.07.19 [e17ec22]) that were required for automated testing was the harder part.

Pleas have a look especially  at the changes of the methods getConfigurationsForBranch() and getDuplicateRowsIfExist () of the class CrawlerController in commit [91e88fc]. I changed them in in a way that the fulfil the test cases from the TYPO3 v8 (current master) branch , but I'm not sure if this is intended.