### PR TITLE
[CI] Add Rector CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ jobs:
     - env: TYPO3_VERSION=^10.0 COVERAGE=0 FUNCTIONAL=0
     - env: TYPO3_VERSION=dev-master COVERAGE=0 FUNCTIONAL=0
     - env: TYPO3_VERSION=dev-master COVERAGE=0 FUNCTIONAL=1
+    - name: "Rector CI"
   include:
     - stage: test
       env: TYPO3_VERSION=^9.5 COVERAGE=0 FUNCTIONAL=0
@@ -117,6 +118,13 @@ jobs:
     - stage: test
       env: TYPO3_VERSION=dev-master COVERAGE=0 FUNCTIONAL=1
       php: 7.3
+
+    # Rector CI
+    - stage: rector
+      name: "Rector CI"
+      php: 7.2
+      script:
+        - .Build/bin/rector process --dry-run
 
     - stage: ship to ter
       if: tag IS present

--- a/Classes/Api/CrawlerApi.php
+++ b/Classes/Api/CrawlerApi.php
@@ -31,7 +31,6 @@ use AOE\Crawler\Domain\Repository\QueueRepository;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Frontend\Page\PageRepository;
 

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -29,10 +29,10 @@ namespace AOE\Crawler\Command;
 use AOE\Crawler\Controller\CrawlerController;
 use AOE\Crawler\Domain\Model\Reason;
 use AOE\Crawler\Event\EventDispatcher;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Command\Command;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -108,7 +108,7 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
      *
      * --- Re-cache pages from page 7 and two levels down, executed immediately
      * $ typo3 crawler:buildQueue --page 7 --depth 2 --conf defaultConfiguration --mode exec
-
+     *
      *
      * --- Put entries for re-caching pages from page 7 into queue, 4 every minute.
      * $ typo3 crawler:buildQueue --page 7 --depth 0 --conf defaultConfiguration --mode queue --number 4
@@ -116,7 +116,6 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
         $mode = $input->getOption('mode');
 
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
@@ -124,7 +123,7 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
         /** @var CrawlerController $crawlerController */
         $crawlerController = $objectManager->get(CrawlerController::class);
 
-        if ( $mode === 'exec') {
+        if ($mode === 'exec') {
             $crawlerController->registerQueueEntriesInternallyOnly = true;
         }
 
@@ -166,7 +165,7 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
             $pageId,
             MathUtility::forceIntegerInRange($input->getOption('depth'), 0, 99),
             $crawlerController->getCurrentTime(),
-            MathUtility::forceIntegerInRange($input->getOption('number') ?:  30, 1, 1000),
+            MathUtility::forceIntegerInRange($input->getOption('number') ?: 30, 1, 1000),
             $mode === 'queue' || $mode === 'exec',
             $mode === 'url',
             [],
@@ -174,31 +173,31 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
         );
 
         if ($mode === 'url') {
-             $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->downloadUrls) . PHP_EOL . '</info>');
+            $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->downloadUrls) . PHP_EOL . '</info>');
         } elseif ($mode === 'exec') {
-             $output->writeln('<info>Executing ' . count($crawlerController->urlList) . ' requests right away:</info>');
-             $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->urlList) . '</info>' . PHP_EOL);
-             $output->writeln('<info>Processing</info>' . PHP_EOL);
+            $output->writeln('<info>Executing ' . count($crawlerController->urlList) . ' requests right away:</info>');
+            $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->urlList) . '</info>' . PHP_EOL);
+            $output->writeln('<info>Processing</info>' . PHP_EOL);
 
             foreach ($crawlerController->queueEntries as $queueRec) {
                 $p = unserialize($queueRec['parameters']);
-                 $output->writeln('<info>' . $p['url'] . ' (' . implode(',', $p['procInstructions']) . ') => ' . '</info>' . PHP_EOL);
+                $output->writeln('<info>' . $p['url'] . ' (' . implode(',', $p['procInstructions']) . ') => ' . '</info>' . PHP_EOL);
                 $result = $crawlerController->readUrlFromArray($queueRec);
 
                 $requestResult = unserialize($result['content']);
                 if (is_array($requestResult)) {
                     $resLog = is_array($requestResult['log']) ? PHP_EOL . chr(9) . chr(9) . implode(PHP_EOL . chr(9) . chr(9), $requestResult['log']) : '';
-                     $output->writeln('<info>OK: ' . $resLog . '</info>' . PHP_EOL);
+                    $output->writeln('<info>OK: ' . $resLog . '</info>' . PHP_EOL);
                 } else {
-                     $output->writeln('<errror>Error checking Crawler Result:  ' . substr(preg_replace('/\s+/', ' ', strip_tags($result['content'])), 0, 30000) . '...' . PHP_EOL . '</errror>' . PHP_EOL);
+                    $output->writeln('<errror>Error checking Crawler Result:  ' . substr(preg_replace('/\s+/', ' ', strip_tags($result['content'])), 0, 30000) . '...' . PHP_EOL . '</errror>' . PHP_EOL);
                 }
             }
         } elseif ($mode === 'queue') {
-             $output->writeln('<info>Putting ' . count($crawlerController->urlList) . ' entries in queue:</info>' . PHP_EOL);
-             $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->urlList) . '</info>' . PHP_EOL);
+            $output->writeln('<info>Putting ' . count($crawlerController->urlList) . ' entries in queue:</info>' . PHP_EOL);
+            $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->urlList) . '</info>' . PHP_EOL);
         } else {
-             $output->writeln('<info>' . count($crawlerController->urlList) . ' entries found for processing. (Use "mode" to decide action):</info>' . PHP_EOL);
-             $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->urlList) . '</info>' . PHP_EOL);
+            $output->writeln('<info>' . count($crawlerController->urlList) . ' entries found for processing. (Use "mode" to decide action):</info>' . PHP_EOL);
+            $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->urlList) . '</info>' . PHP_EOL);
         }
     }
 
@@ -213,6 +212,4 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
         $parameter = trim($conf);
         return ($parameter != '' ? GeneralUtility::trimExplode(',', $parameter) : []);
     }
-
-
 }

--- a/Classes/Command/FlushQueueCommand.php
+++ b/Classes/Command/FlushQueueCommand.php
@@ -27,10 +27,10 @@ namespace AOE\Crawler\Command;
  ***************************************************************/
 
 use AOE\Crawler\Controller\CrawlerController;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Command\Command;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -58,7 +58,7 @@ It will remove queue entries and perform a cleanup.' . chr(10) . chr(10) .
             InputOption::VALUE_OPTIONAL,
             'Output mode',
             'finished'
-		);
+        );
 
         $this->addOption(
             'page',
@@ -107,6 +107,4 @@ It will remove queue entries and perform a cleanup.' . chr(10) . chr(10) .
                 break;
         }
     }
-
-
 }

--- a/Classes/Command/ProcessQueueCommand.php
+++ b/Classes/Command/ProcessQueueCommand.php
@@ -135,5 +135,4 @@ class ProcessQueueCommand extends Command
 
         return $output->writeln($result);
     }
-
 }

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -25,12 +25,12 @@ namespace AOE\Crawler\Controller;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use AOE\Crawler\QueueExecutor;
 use AOE\Crawler\Configuration\ExtensionConfigurationProvider;
 use AOE\Crawler\Domain\Repository\ConfigurationRepository;
 use AOE\Crawler\Domain\Repository\ProcessRepository;
 use AOE\Crawler\Domain\Repository\QueueRepository;
 use AOE\Crawler\Event\EventDispatcher;
+use AOE\Crawler\QueueExecutor;
 use AOE\Crawler\Utility\SignalSlotUtility;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -449,7 +449,6 @@ class CrawlerController implements LoggerAwareInterface
         array &$downloadUrls,
         array $incomingProcInstructions
     ) {
-
         if (!is_array($vv['URLs'])) {
             return 'ERROR - no URL generated';
         }
@@ -1359,7 +1358,7 @@ class CrawlerController implements LoggerAwareInterface
      */
     public function readUrlFromArray($field_array)
     {
-            // Set exec_time to lock record:
+        // Set exec_time to lock record:
         $field_array['exec_time'] = $this->getCurrentTime();
         $connectionForCrawlerQueue = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($this->tableName);
         $connectionForCrawlerQueue->insert(

--- a/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
+++ b/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
@@ -59,7 +59,7 @@ class GuzzleExecutionStrategy implements LoggerAwareInterface
                 sprintf('Error while opening "%s" - ' . $e->getResponse()->getStatusCode() . chr(32) . $e->getResponse()->getReasonPhrase(), $url),
                 ['crawlerId' => $crawlerId]
             );
-            return $e->getResponse()->getStatusCode() . chr(32) .  $e->getResponse()->getReasonPhrase();
+            return $e->getResponse()->getStatusCode() . chr(32) . $e->getResponse()->getReasonPhrase();
         }
     }
 
@@ -77,5 +77,4 @@ class GuzzleExecutionStrategy implements LoggerAwareInterface
             'User-Agent' => 'TYPO3 crawler'
         ];
     }
-
 }

--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -243,4 +243,3 @@ class Configuration extends AbstractEntity
         $this->exclude = $exclude;
     }
 }
-

--- a/Classes/Domain/Repository/ConfigurationRepository.php
+++ b/Classes/Domain/Repository/ConfigurationRepository.php
@@ -62,7 +62,6 @@ class ConfigurationRepository extends AbstractRepository
         return $records;
     }
 
-
     /**
      * Traverses up the rootline of a page and fetches all crawler records.
      *

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -28,7 +28,6 @@ namespace AOE\Crawler\Domain\Repository;
 use AOE\Crawler\Domain\Model\Process;
 use AOE\Crawler\Domain\Model\Queue;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 

--- a/Classes/Middleware/CrawlerInitialization.php
+++ b/Classes/Middleware/CrawlerInitialization.php
@@ -15,7 +15,6 @@ namespace AOE\Crawler\Middleware;
  * The TYPO3 project - inspiring people to share!
  */
 
-
 use AOE\Crawler\Domain\Repository\QueueRepository;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -142,5 +141,4 @@ class CrawlerInitialization implements MiddlewareInterface
             }
         }
     }
-
 }

--- a/Classes/QueueExecutor.php
+++ b/Classes/QueueExecutor.php
@@ -15,12 +15,11 @@ namespace AOE\Crawler;
  * The TYPO3 project - inspiring people to share!
  */
 
-
+use AOE\Crawler\Configuration\ExtensionConfigurationProvider;
+use AOE\Crawler\Controller\CrawlerController;
 use AOE\Crawler\CrawlStrategy\CallbackExecutionStrategy;
 use AOE\Crawler\CrawlStrategy\GuzzleExecutionStrategy;
 use AOE\Crawler\CrawlStrategy\SubProcessExecutionStrategy;
-use AOE\Crawler\Configuration\ExtensionConfigurationProvider;
-use AOE\Crawler\Controller\CrawlerController;
 use AOE\Crawler\Event\EventDispatcher;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\SingletonInterface;

--- a/Classes/Worker/CrawlerWorker.php
+++ b/Classes/Worker/CrawlerWorker.php
@@ -16,8 +16,8 @@ namespace AOEPeople\Crawler\Worker;
 
 use AOE\Crawler\Controller\CrawlerController;
 use AOEPeople\Crawler\Hooks\IndexedSearchCrawlerFilesHook;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\TimeTracker\TimeTracker;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\IndexedSearch\Worker\WorkerInterface;
 
 class CrawlerWorker implements WorkerInterface
@@ -44,7 +44,7 @@ class CrawlerWorker implements WorkerInterface
 
         $params = [
             'document' => $contentTmpFile,
-            'alturl' =>$file,
+            'alturl' => $file,
             'conf' => $conf
         ];
 

--- a/Tests/Functional/Domain/Repository/ProcessRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ProcessRepositoryTest.php
@@ -27,7 +27,6 @@ namespace AOE\Crawler\Tests\Functional\Domain\Repository;
 
 use AOE\Crawler\Domain\Repository\ProcessRepository;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
-use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 

--- a/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
@@ -26,7 +26,6 @@ namespace AOE\Crawler\Tests\Functional\Domain\Repository;
  ***************************************************************/
 
 use AOE\Crawler\Domain\Model\Process;
-use AOE\Crawler\Domain\Model\Queue;
 use AOE\Crawler\Domain\Repository\QueueRepository;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Tests/Unit/Controller/CrawlerControllerTest.php
+++ b/Tests/Unit/Controller/CrawlerControllerTest.php
@@ -25,7 +25,6 @@ namespace AOE\Crawler\Tests\Unit\Controller;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use AOE\Crawler\Command\QueueCommandLineController;
 use AOE\Crawler\Controller\CrawlerController;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 use Psr\Log\NullLogger;

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "nimut/testing-framework": "^4.1",
         "nimut/typo3-complete": "^9.5",
         "friendsofphp/php-cs-fixer": "^2.15",
-        "phpstan/phpstan": "^0.11.4"
+        "phpstan/phpstan": "^0.11.4",
+        "rector/rector": "^0.6.0@dev"
     },
     "replace": {
         "typo3-ter/crawler": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": ">=7.2",
         "ext-json": "*",

--- a/rector-ci.yaml
+++ b/rector-ci.yaml
@@ -1,0 +1,20 @@
+parameters:
+    paths:
+        - "Classes"
+        - "Configuration"
+        - "Migrations"
+        - "Tests"
+
+    sets:
+        - "dead-code"
+
+    auto_import_names: false
+
+    autoload_paths:
+        - "Classes"
+
+    exclude_paths:
+        # missing parent interface "TYPO3\CMS\IndexedSearch\Worker\WorkerInterface"
+        - "Classes/Worker/CrawlerWorker.php"
+        # BC layer
+        - "Migrations/Code/LegacyClassesForIde.php"


### PR DESCRIPTION
Based on @rectorphp [start contest](https://twitter.com/rectorphp/status/1196711403333332992) I send my first PR :) more are comming. Step by step.

**Feature:** adds first Rector run to CI.

The coding style was fixed somehow automatically.

The `"prefer-stable": true` in `composer.json` is best practise for development with dev dependencies (`"minimum-stability": "dev"`), so you always works with the same dependencies as the end user. It also speeds up composer install/update brutally.