### PR TITLE
[BUGFIX] Set user aspect with fe groups during indexing

### DIFF
--- a/Classes/Middleware/CrawlerInitialization.php
+++ b/Classes/Middleware/CrawlerInitialization.php
@@ -25,6 +25,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\UserAspect;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -102,7 +103,17 @@ class CrawlerInitialization implements MiddlewareInterface
             }
             $GLOBALS['TSFE']->fe_user->user['usergroup'] = $grList;
             $GLOBALS['TSFE']->applicationData['tx_crawler']['log'][] = 'User Groups: ' . $grList;
-            // @todo: set the frontend user aspect again.
+            // we has to set the fe user group to the user aspect since indexed_search only reads the user aspect
+            // to get the groups.  otherwise groups are ignored during indexing.
+            // we need to add the groups 0, and -2 too, like the getGroupIds getter does.
+            $this->context->setAspect(
+                'frontend.user',
+                GeneralUtility::makeInstance(
+                    UserAspect::class,
+                    $GLOBALS['TSFE']->fe_user,
+                    explode(',', '0,-2,' . $grList)
+                )
+            );
         }
 
         // Execute the frontend request as is


### PR DESCRIPTION
Currently the fe user group list is not indexed.
indexed_search reads the ids from the `frontend.user`, `groupIds` aspect. 
See https://github.com/TYPO3-CMS/indexed_search/blob/v9.5.13/Classes/Indexer.php#L308

The groups are not stored in the aspect currently, so the default groups `0,-1` are indexed, what's wrong.

This PR fixes the indexing if there are fe groups defined.

Currently there is no setter for the groups in the aspect, so i think we has to create a new user aspect.

The 0 and -2 has to be set to the group too, like the getter does. See https://github.com/TYPO3/TYPO3.CMS/blob/v9.5.13/typo3/sysext/core/Classes/Context/UserAspect.php#L134