### PR TITLE
[BUGFIX] Load crawler initialization before page resolver

### DIFF
--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -12,6 +12,9 @@ return [
                 'typo3/cms-frontend/tsfe',
                 'typo3/cms-frontend/authentication',
             ],
+            'before' => [
+                'typo3/cms-frontend/page-resolver',
+            ],
         ],
     ],
 ];


### PR DESCRIPTION
The initialisation of the crawler has to be performed before the page resolver kicks in. otherwise the fe user groups could not be set and the page resolver responses a 403 for restricted pages.