### PR TITLE
[BUGFIX] Fix type error in build queue command

### DIFF
--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -122,7 +122,7 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
 
         $pageId = MathUtility::forceIntegerInRange($input->getOption('page'), 0);
 
-        $configurationKeys = $this->getConfigurationKeys($input->getOption('conf'));
+        $configurationKeys = $this->getConfigurationKeys((string) $input->getOption('conf'));
 
         if (!is_array($configurationKeys)) {
             $configurations = $crawlerController->getUrlsForPageId($pageId);


### PR DESCRIPTION
When i don't add the optional option `conf` a PHP Type Error are thrown, becouse `$conf` becomes `null` instead of string:
```text
trim() expects parameter 1 to be string, null given 
thrown in file typo3conf/ext/crawler/Classes/Command/BuildQueueCommand.php 
in line 200
```
This PR fixes the problem by casting the `conf` option into a string.

The command i use to reproduce this:
```bash
bin/typo3 crawler:buildQueue -p 2 -d 99 -m queue
```