### PR TITLE
[BUG FIX] Extensions throws Invalide argument exception with TYPO3 v9…

### DIFF
--- a/Classes/Backend/BackendModule.php
+++ b/Classes/Backend/BackendModule.php
@@ -426,7 +426,7 @@ class BackendModule
         );
 
         // Configurations
-        $availableConfigurations = $this->crawlerController->getConfigurationsForBranch((int)$this->id, $this->pObj->MOD_SETTINGS['depth'] ?: 0);
+        $availableConfigurations = $this->crawlerController->getConfigurationsForBranch((int)$this->id, (int)$this->pObj->MOD_SETTINGS['depth'] ?: 0);
         $selectors['configurations'] = $this->selectorBox(
             empty($availableConfigurations) ? [] : array_combine($availableConfigurations, $availableConfigurations),
             'configurationSelection',


### PR DESCRIPTION
….5.14

Extension throws a fatal error while depth is infinite level when you Start Crawling. 

`	
Oops, an error occurred!
Argument 2 passed to AOE\Crawler\Controller\CrawlerController::getConfigurationsForBranch() must be of the type integer, string given, called in /var/www/html/GNB/T3Demos/TYPO3.CMS.9/typo3conf/ext/crawler/Classes/Backend/BackendModule.php on line 429`

Configuration: https://prnt.sc/rav5xu
Error: https://prnt.sc/rav6k1