### PR TITLE
[TASK] Add branch alias for 9.0.x-dev in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,6 +100,9 @@
         ]
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        },
         "typo3/cms": {
             "cms-package-dir": "{$vendor-dir}/typo3/cms",
             "web-dir": ".Build/Web"


### PR DESCRIPTION
The branch alias was removed recently in edca84df2cacdaf89a8cbc47fcb20ed9a6f17c22. However, as development continues in the master branch, this is still needed but now with reference to `dev-master`. Additionally, the alias version should be variable `9.0.x-dev` instead of the hardcoded `9.0.0-dev`.