### PR TITLE
[FIX] get fe_user from $GLOBALS['TSFE']

### DIFF
--- a/Classes/Middleware/FrontendUserAuthenticator.php
+++ b/Classes/Middleware/FrontendUserAuthenticator.php
@@ -83,7 +83,7 @@ class FrontendUserAuthenticator implements MiddlewareInterface
         // Now ensure to set the proper user groups
         $grList = $queueParameters['feUserGroupList'];
         if ($grList) {
-            $frontendUser = $request->getAttribute('frontend.user');
+            $frontendUser = $GLOBALS['TSFE']->fe_user;
             $frontendUser->user[$frontendUser->usergroup_column] = $grList;
             // we have to set the fe user group to the user aspect since indexed_search only reads the user aspect
             // to get the groups. otherwise groups are ignored during indexing.


### PR DESCRIPTION
Setting the $frontendUser with $request->getAttribute('frontend.user') resulted in a \stdClass

Since this middleware is called after the core fe_user authenticator we can assume an instance of FrontendUserAuthentication is set in $GLOBALS['TSFE']->fe_user