### PR TITLE
[BUGFIX] Handle empty response when fetching URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog TYPO3 Crawler
 
+### Changed
+* Handle empty response when fetching URL
+
 ## Crawler 9.0.1
 Crawler 9.0.1 was released on May 11th, 2020
 

--- a/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
+++ b/Classes/CrawlStrategy/GuzzleExecutionStrategy.php
@@ -57,11 +57,16 @@ class GuzzleExecutionStrategy implements LoggerAwareInterface
             $contents = $response->getBody()->getContents();
             return unserialize($contents);
         } catch (RequestException $e) {
+            $response = $e->getResponse();
+            $message = ($response ? $response->getStatusCode() : 0)
+                . chr(32)
+                . ($response ? $response->getReasonPhrase() : $e->getMessage());
+
             $this->logger->debug(
-                sprintf('Error while opening "%s" - ' . $e->getResponse()->getStatusCode() . chr(32) . $e->getResponse()->getReasonPhrase(), $url),
+                sprintf('Error while opening "%s" - ' . $message, $url),
                 ['crawlerId' => $crawlerId]
             );
-            return $e->getResponse()->getStatusCode() . chr(32) . $e->getResponse()->getReasonPhrase();
+            return $message;
         }
     }
 


### PR DESCRIPTION
This case can occur, when the connection is resetted from the server.

Resolves: #587
Related: #584