### PR TITLE
[TASK] List specific doktypes for skipping page

### DIFF
--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -338,7 +338,7 @@ class CrawlerController implements LoggerAwareInterface
         }
 
         if (! $skipPage) {
-            if (GeneralUtility::inList('3,4', $pageRow['doktype']) || $pageRow['doktype'] >= 199) {
+            if (GeneralUtility::inList('3,4,199,254,255', $pageRow['doktype'])) {
                 $skipPage = true;
                 $skipMessage = 'Because doktype is not allowed';
             }


### PR DESCRIPTION
With TYPO3 10.4 the limitation of custom doktypes to a number less
than 200 was lifted. This patch makes it possible to crawl on custom
doktypes with a number greater than 200.

See also:
- https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.4/Important-18079-PagesdoktypeRestrictionForFrontendQueriesRefined.html
- https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/core/Classes/Domain/Repository/PageRepository.php#L103