### PR TITLE
[TASK] Introduce .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+.devbox export-ignore
+.Docker export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.github export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+codeception.yml export-ignore
+crowdin.yml export-ignore
+ecs.yaml export-ignore
+phpstan.neon export-ignore
+rector-ci.yaml export-ignore
+sonar-project.properties export-ignore
+Tests export-ignore


### PR DESCRIPTION
Files and folders which are defined as export-ignore are not
included in an archive and therefore not installed via composer
on production systems.