### PR TITLE
[TASK] Add description to commands

### DIFF
--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -38,6 +38,8 @@ class BuildQueueCommand extends Command
 {
     protected function configure(): void
     {
+        $this->setDescription('Create entries in the queue that can be processed at once');
+
         $this->setHelp(
             'Try "typo3 help crawler:buildQueue" to see your options' . chr(10) . chr(10) .
             'Works as a CLI interface to some functionality from the Web > Info > Site Crawler module;

--- a/Classes/Command/FlushQueueCommand.php
+++ b/Classes/Command/FlushQueueCommand.php
@@ -33,6 +33,8 @@ class FlushQueueCommand extends Command
 {
     protected function configure(): void
     {
+        $this->setDescription('Remove queue entries and perform a cleanup');
+
         $this->setHelp(
             'Try "typo3 help crawler:flushQueue" to see your options' . chr(10) . chr(10) .
             'Works as a CLI interface to some functionality from the Web > Info > Site Crawler module;

--- a/Classes/Command/ProcessQueueCommand.php
+++ b/Classes/Command/ProcessQueueCommand.php
@@ -110,12 +110,14 @@ class ProcessQueueCommand extends Command
 
     protected function configure(): void
     {
+        $this->setDescription('Trigger the crawler to process the queue entries');
+
         $this->setHelp(
             'Crawler Command - Crawling the URLs from the queue' . chr(10) . chr(10) .
             '
             Examples:
               --- Will trigger the crawler which starts to process the queue entries
-              $ typo3 crawler:processqueue --amount 15 --sleepafter 5 --sleeptime 2  
+              $ typo3 crawler:processqueue --amount 15 --sleepafter 5 --sleeptime 2
             '
         );
         $this->addOption(


### PR DESCRIPTION
The descriptions are shown in the overview of available commands when
vendor/bin/typo3 is called without any parameter.