### PR TITLE
[BUGFIX] Set default value when procInstrFilter is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 * Handle empty response when fetching URL [@brotkrueml](https://github.com/brotkrueml)
+* Set default value when procInstrFilter is not defined [@brotkrueml](https://github.com/brotkrueml)
 
 ## Crawler 9.0.1
 Crawler 9.0.1 was released on May 11th, 2020

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -550,7 +550,7 @@ class CrawlerController implements LoggerAwareInterface
             $subCfg = (array) $crawlerCfg[$key . '.'];
             $subCfg['key'] = $key;
 
-            if (strcmp($subCfg['procInstrFilter'], '')) {
+            if (strcmp($subCfg['procInstrFilter'] ?? '', '')) {
                 $subCfg['procInstrFilter'] = implode(',', GeneralUtility::trimExplode(',', $subCfg['procInstrFilter']));
             }
             $pidOnlyList = implode(',', GeneralUtility::trimExplode(',', $subCfg['pidsOnly'], true));


### PR DESCRIPTION
The type error "strcmp() expects parameter 1 to be string, null given" was
raised when using a PageTS configuration without "procInstrFilter" defined
(at least under PHP 7.4).