### PR TITLE
[TASK] Revise documentation syntax

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
+
+[*.rst]
+indent_size = 3
+max_line_length = 80

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ var/tests
 # Codeception Files
 Tests/Acceptance/_data/*
 Tests/Acceptance/_output/*
+
+# Generated documentation
+Documentation-GENERATED-temp

--- a/Documentation/Aoe/Aoe.rst
+++ b/Documentation/Aoe/Aoe.rst
@@ -1,18 +1,14 @@
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+.. include:: /Includes.txt
 
-.. include:: ../Includes.txt
-
+========
 AOE GmbH
---------
+========
 
  | `AOE <http://www.aoe.com/>`_ develops digital marketplace and e-commerce platform solutions based on Open Source technologies.
  | We specialize in the implementation of complex enterprise software applications for global corporations.
  | Headquartered in Wiesbaden and with more than 300 employees in five countries, AOE serves global companies such as
  | congstar, Deutsche Telekom, Heathrow, Singapore Airlines, Commerz Real, Sony, Panasonic and Frankfurt Airport.
- | 
+ |
  | AOE supports its customers in the development of digital business models and consistently rely on agile methods.
  | In long-term agile projects, we execute innovative solutions with automated and digitalized processes together with our customers.
  | In addition, AOE develops its own products such as the Open Source framework Flamingo ( `www.flamingo.me <http://www.flamingo.me/>`_ )

--- a/Documentation/Configuration/ConfigurationRecords/Index.rst
+++ b/Documentation/Configuration/ConfigurationRecords/Index.rst
@@ -1,34 +1,22 @@
-﻿
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
 .. _backend-configuration-record:
 
+=====================
 Configuration records
-^^^^^^^^^^^^^^^^^^^^^
+=====================
 
 Formerly configuration was done by using pageTS (see below). This is
 still possible (fully backwards compatible) but not recommended.
 Instead of writing pageTS simply create a configuration record (table:
-tx\_crawler\_configuration) and put it on the topmost page of the
+``tx_crawler_configuration``) and put it on the topmost page of the
 pagetree you want to affect with this configuration.
 
-The fields in these records are related to the page ts keys described
+The fields in these records are related to the pageTS keys described
 below.
 
 Fields and their pageTS equivalents
-'''''''''''''''''''''''''''''''''''
+===================================
 
 - **Name** - corresponds to the "key" part in the pageTS setup
   e.g. tx_crawler.crawlerCfg.paramSets.myConfigurationKeyName

--- a/Documentation/Configuration/ExtensionManagerConfiguration/Index.rst
+++ b/Documentation/Configuration/ExtensionManagerConfiguration/Index.rst
@@ -1,26 +1,20 @@
-﻿.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
 .. _extension-manager-configuration:
 
-
+===============================
 Extension Manager Configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+===============================
 
 A lot of options were added to the extension manager configuration,
 that allow settings to improve and enable new crawler features:
 
-.. image:: /Images/backend_configuration_settings.png
+.. figure:: /Images/backend_configuration_settings.png
+   :alt: Backend configuration: Settings
 
-.. image:: /Images/backend_configuration_queue.png
+   Backend configuration: Settings
 
+.. figure:: /Images/backend_configuration_queue.png
+   :alt: Backend configuration: Queue
+
+   Backend configuration: Queue

--- a/Documentation/Configuration/HttpAuthentication/Index.rst
+++ b/Documentation/Configuration/HttpAuthentication/Index.rst
@@ -1,24 +1,12 @@
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-
-:class:  typoscript
-.. role::   php(code)
-
-
+===================
 HTTP Authentication
-^^^^^^^^^^^^^^^^^^^
+===================
 
-If you want to use HTTP Authentication you  need to configure your base url to contain user:pass
+If you want to use HTTP Authentication you need to configure your base url
+to contain user:pass
 
-::
+.. code-block:: text
 
-    http://user:pass@www.mydomain.com/
+   https://user:pass@www.mydomain.com/

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -1,23 +1,8 @@
-﻿
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+=============
 Configuration
--------------
-
+=============
 
 .. toctree::
    :maxdepth: 5
@@ -28,4 +13,3 @@ Configuration
    ConfigurationRecords/Index
    PageTsconfigReference(txCrawlercrawlercfg)/Index
    HttpAuthentication/Index
-

--- a/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
+++ b/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
@@ -1,39 +1,11 @@
-﻿
+﻿.. include:: /Includes.txt
+.. highlight:: typoscript
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+================================================
 Page TSconfig Reference (tx\_crawler.crawlerCfg)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+================================================
 
 .. ### BEGIN~OF~TABLE ###
-
-.. container:: table-row
-
-   Property
-         Property:
-
-   Data type
-         Data type:
-
-   Description
-         Description:
-
-   Default
-         Default:
-
 
 .. container:: table-row
 
@@ -108,8 +80,7 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
                  procInstrFilter = tx_indexedsearch_reindex
                }
             }
-            
-   Default
+
 
 
 .. container:: table-row
@@ -124,11 +95,9 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
 
    Description
          List of processing instructions, eg. "tx\_indexedsearch\_reindex" from
-         indexed\_searchto send for the request. Processing instructions are
+         indexed\_search to send for the request. Processing instructions are
          necessary for the request to perform any meaningful action, since they
          activate third party activity.
-
-   Default
 
 
 .. container:: table-row
@@ -147,8 +116,6 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
 
          .....procInstrParams.tx\_staticpub\_publish.includeResources=1
 
-   Default
-
 
 .. container:: table-row
 
@@ -163,8 +130,6 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
    Description
          List of Page Ids to limit this configuration to
 
-   Default
-
 
 .. container:: table-row
 
@@ -178,8 +143,6 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
 
    Description
          User groups to set for the request.
-
-   Default
 
 
 .. container:: table-row
@@ -199,8 +162,6 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
          MUST BE SET if run from CLI (since TYPO3\_SITE\_URL does not exist in
          that context!)
 
-   Default
-
 
 .. ###### END~OF~TABLE ######
 
@@ -208,12 +169,12 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
 
 
 Example
-~~~~~~~
+=======
 
 ::
 
    tx_crawler.crawlerCfg.paramSets.test = &L=[0-3]
    tx_crawler.crawlerCfg.paramSets.test {
-           procInstrFilter = tx_indexedsearch_reindex
+      procInstrFilter = tx_indexedsearch_reindex
    }
 

--- a/Documentation/ExecutingTheQueue/BuildingAndExecutingQueueRightAway(fromCli)/Index.rst
+++ b/Documentation/ExecutingTheQueue/BuildingAndExecutingQueueRightAway(fromCli)/Index.rst
@@ -1,20 +1,10 @@
-﻿.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
 .. _executing-the-queue-cli-label:
 
+==================================================
 Building and Executing queue right away (from cli)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==================================================
 
 An alternative mode is to automatically build and execute the queue
 from the command line in one process. This doesn't allow scheduling of
@@ -26,7 +16,7 @@ The script to use is this:
 
 ::
 
-   [pathToYourTYPO3Installation-composer-bin-dir]/typo3cms crawler:buildQueue <startPageUid> <configurationKeys>
+   vendor/bin/typo3 crawler:buildQueue <startPageUid> <configurationKeys>
 
 If you run it you will see a list of options which explains usage.
 
@@ -99,14 +89,14 @@ If you run it you will see a list of options which explains usage.
    Description
          Output mode: "url", "exec", "queue"
 
-         \- url : Will list URLs which wget could use as input.
+         - url : Will list URLs which wget could use as input.
 
-         \- queue: Will put entries in queue table.
+         - queue: Will put entries in queue table.
 
-         \- exec: Will execute all entries right away!
+         - exec: Will execute all entries right away!
 
    Default
-         Queue
+         queue
 
 
 .. container:: table-row
@@ -141,11 +131,11 @@ To do the same with the CLI script you run this:
 
 ::
 
-   [pathToYourTYPO3Installation-composer-bin-dir]/typo3 crawler:buildQueue 6 default --depth 2
+   vendor/bin/typo3 crawler:buildQueue 6 default --depth 2
 
 And this is the output:
 
-::
+.. code-block:: text
 
     38 entries found for processing. (Use "mode" to decide action):
 

--- a/Documentation/ExecutingTheQueue/ExecutingQueueWithCron-job/Index.rst
+++ b/Documentation/ExecutingTheQueue/ExecutingQueueWithCron-job/Index.rst
@@ -1,32 +1,20 @@
-﻿.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+=============================
 Executing queue with cron-job
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=============================
 
 A "cron-job" refers to a script that runs on the server with time
 intervals.
 
 For this to become reality you must ideally have a cron-job set up.
 This assumes you are running on Unix architecture of some sort. The
-crontab is often edited by "crontab -e" and you should insert a line
+crontab is often edited by :shell:`crontab -e` and you should insert a line
 like this:
 
 ::
 
-   * * * * * [pathToYourTYPO3Installation-composer-bin-dir]/typo3cms crawler:buildQueue <startpage> <configurationKeys> > /dev/null
+   * * * * * vendor/bin/typo3 crawler:buildQueue <startpage> <configurationKeys> > /dev/null
 
 This will run the script every minute. You should try to run the
 script on the command line first to make sure it runs without any
@@ -38,10 +26,13 @@ as a CGI script as well in /usr/bin/.
 The user "\_cli\_" is created by the framework on demand if it does not exist
 at the first command line call.
 
-In the "CLI status" menu of the Site Crawler info module you can see
-the status:
+In the :guilabel:`CLI status` menu of the :guilabel:`Site Crawler` info module
+you can see the status:
 
-.. image:: /Images/backend_processlist.png
+.. figure:: /Images/backend_processlist.png
+   :alt: Status page in the backend
+
+   Status page in the backend
 
 This is how it looks just after you ran the script. (You can also see
 the full path to the script in the bottom - this is the path to the
@@ -58,4 +49,3 @@ calls to the crawler CLI script will not run parallel processes. So
 the second call will just exit if it finds in the status file that the
 process is already running. But of course a crashed script will fail
 to set the status to "end" and hence this situation can occur.
-

--- a/Documentation/ExecutingTheQueue/Index.rst
+++ b/Documentation/ExecutingTheQueue/Index.rst
@@ -1,22 +1,10 @@
-﻿
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
 .. _executing-the-queue-label:
 
+===================
 Executing the queue
--------------------
+===================
 
 The idea of the queue is that a large number of tasks can be submitted
 to the queue and performed over longer time. This could be interesting
@@ -24,10 +12,10 @@ for several reasons;
 
 - To spread server load over time.
 
-- To time the requests for nightly processing
+- To time the requests for nightly processing.
 
 - And simply to avoid "max\_execution\_time" of PHP to limit processing
-  to 30 seconds !
+  to 30 seconds!
 
 
 .. toctree::
@@ -39,4 +27,3 @@ for several reasons;
    ExecutingQueueWithCron-job/Index
    RunViaBackend/Index
    BuildingAndExecutingQueueRightAway(fromCli)/Index
-

--- a/Documentation/ExecutingTheQueue/RunViaBackend/Index.rst
+++ b/Documentation/ExecutingTheQueue/RunViaBackend/Index.rst
@@ -1,28 +1,21 @@
-﻿.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+===============
 Run via backend
-^^^^^^^^^^^^^^^
+===============
 
 To process the queue you must either set up a cron-job on your server
-or use the backend to execute the queue:
+or use the backend to process the queue:
 
-.. image:: /Images/backend_processlist_add_process.png
+.. figure:: /Images/backend_processlist_add_process.png
+   :alt: Process the queue via backend
 
-You can also (re-)crawl singly urls manually from within the Crawler
-log view in the info module:
+   Process the queue via backend
 
-.. image:: /Images/backend_crawlerlog_recrawl.png
+You can also (re-)crawl single URLs manually from within the :guilabel:`Crawler
+log` view in the info module:
 
+.. figure:: /Images/backend_crawlerlog_recrawl.png
+   :alt: Crawl single URLs via backend
+
+   Crawl single URLs via backend

--- a/Documentation/ExecutingTheQueue/RunningViaCommandController/Index.rst
+++ b/Documentation/ExecutingTheQueue/RunningViaCommandController/Index.rst
@@ -1,20 +1,10 @@
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
 .. _command-controller:
 
+==========================
 Run via command controller
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+==========================
 
 Create queue
 ------------

--- a/Documentation/Features/Hooks/Index.rst
+++ b/Documentation/Features/Hooks/Index.rst
@@ -1,25 +1,12 @@
-﻿
+﻿.. include:: /Includes.txt
+.. highlight:: php
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+=====
 Hooks
-^^^^^
+=====
 
 excludeDoktype Hook
-~~~~~~~~~~~~~~~~~~~
+===================
 
 By adding doktype ids to following array you can exclude them from
 being crawled:
@@ -30,7 +17,7 @@ being crawled:
 
 
 pageVeto Hook
-~~~~~~~~~~~~~
+=============
 
 You can also decide whether a page should not be crawled in an
 individual userfunction. Register your function here:

--- a/Documentation/Features/Index.rst
+++ b/Documentation/Features/Index.rst
@@ -1,22 +1,8 @@
-﻿
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+========
 Features
---------
+========
 
 
 .. toctree::

--- a/Documentation/Features/MultiprocessSupport/Index.rst
+++ b/Documentation/Features/MultiprocessSupport/Index.rst
@@ -1,22 +1,8 @@
-﻿
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+=====================
 Multi process support
-^^^^^^^^^^^^^^^^^^^^^
+=====================
 
 If you want to optimize the crawling process for speed (instead of low
 server stress), maybe because the machine is a dedicated staging
@@ -29,5 +15,7 @@ crawling processes per minute. You'll be able to speed up the crawler quite a lo
 
 But choose your settings carefully as it puts loads on the server.
 
-.. image:: /Images/crawler_settings_processLimit.png
+.. figure:: /Images/crawler_settings_processLimit.png
+   :alt: Backend configuration: Processing
 
+   Backend configuration: Processing

--- a/Documentation/Features/PollableProcessingInstructions/Index.rst
+++ b/Documentation/Features/PollableProcessingInstructions/Index.rst
@@ -1,22 +1,9 @@
-﻿
+﻿.. include:: /Includes.txt
+.. highlight:: php
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+================================
 Pollable processing instructions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+================================
 
 Some processing instructions are never executed on the "client side"
 (the TYPO3 frontend that is called by the crawler). This happens for

--- a/Documentation/Includes.txt
+++ b/Documentation/Includes.txt
@@ -6,6 +6,7 @@
 .. role:: js(code)
 .. role:: php(code)
 .. role:: sep (strong)
+.. role:: shell(code)
 .. role:: yaml(code)
 .. role:: underline
 .. role:: typoscript(code)
@@ -13,5 +14,4 @@
 .. role:: ts(typoscript)
    :class: typoscript
 
-.. default-role:: code
 .. highlight:: php

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -15,7 +15,7 @@ Crawler
 :Author:          Kasper Skårhøj, Daniel Pötzinger, Fabrizio Branca, Tolleiv Nietsch, Timo Schmidt, Michael Klapper, Stefan Rotsch, Tomas Norre Mikkelsen
 :Email:           dev@aoe.com
 :License:         This document is published under the Open Content License available from
-                  http://www.opencontent.org/opl.shtml
+                  https://www.opencontent.org/openpub/
 :Rendered:        |today|
 
 The content of this document is related to TYPO3, a GNU/GPL CMS/Framework available from https://typo3.org/.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,21 +1,8 @@
-﻿.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+============
 Introduction
-------------
-
+============
 
 .. toctree::
    :maxdepth: 5

--- a/Documentation/Introduction/Screenshots/Index.rst
+++ b/Documentation/Introduction/Screenshots/Index.rst
@@ -1,37 +1,33 @@
-﻿.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+===========
 Screenshots
-^^^^^^^^^^^
+===========
 
-Has a backend module which displays the queue and log and allows
-execution and status check of the "cronscript" from the backend for
+The extension provides a backend module which displays the queue and log and
+allows execution and status check of the "cronscript" from the backend for
 testing purposes.
 
-Here is the CLI (Command Line Interface = shell script = cron script)
-status display:
+
+CLI status display
+==================
+
+CLI = Command Line Interface = shell script = cron script
 
 .. image:: /Images/backend_processlist.png
 
-Here is the crawler queue (before processing) / log (after processing)
+
+Crawler queue (before processing) / log (after processing)
+==========================================================
 
 .. image:: /Images/backend_crawlerlog.png
 
-Here is the interface for submitting a batch of URLs to be
-crawled. The parameter combinations are programmeble through Page
-Tsconfig or configuration records.
+
+Interface for submitting a batch of URLs to be crawled
+======================================================
+
+The parameter combinations are programmeble through Page TSconfig or
+configuration records.
 
 .. image:: /Images/backend_pendingurls.png
 

--- a/Documentation/Introduction/WhatDoesItDo/Index.rst
+++ b/Documentation/Introduction/WhatDoesItDo/Index.rst
@@ -1,22 +1,8 @@
-﻿
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+================
 What does it do?
-^^^^^^^^^^^^^^^^
+================
 
 Uses a command line cron-script to traverse a queue of actions
 (alternative option: executing all immediately), eg. requesting a URL
@@ -39,4 +25,3 @@ extensions (and indexed search is one of them). In this way a
 processing instruction can instruct the frontend to perform an action
 (like indexing, publishing etc.) which cannot be done with a request
 from outside.
-

--- a/Documentation/Links/Links.rst
+++ b/Documentation/Links/Links.rst
@@ -1,16 +1,10 @@
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. include:: ../Includes.txt
-
+.. include:: /Includes.txt
 
 .. _links:
 
-
+=====
 Links
------
+=====
 
 :TER:
     	https://extensions.typo3.org/extension/crawler/

--- a/Documentation/Scheduler/Index.rst
+++ b/Documentation/Scheduler/Index.rst
@@ -1,20 +1,8 @@
-﻿.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+=========
 Scheduler
----------
+=========
 
 
 .. toctree::
@@ -23,29 +11,40 @@ Scheduler
    :glob:
 
 
-As seen in :ref:`executing-the-queue-label` you can execute the queue in multiple ways, but it's no fun doing that manually all the time.
+As seen in :ref:`executing-the-queue-label` you can execute the queue in
+multiple ways, but it's no fun doing that manually all the time.
 
-With the Crawler you have the possibility to add Scheduler Tasks to be executed on a give time.
-The Crawler commands are implemented with the Symfony Console, and therefore they can be configured with the Core supported `Execute console commands (scheduler)` task.
+With the Crawler you have the possibility to add Scheduler Tasks to be executed
+on a give time. The Crawler commands are implemented with the Symfony Console,
+and therefore they can be configured with the Core supported
+`Execute console commands (scheduler)` task.
 
-So how to setup crawler scheduler tasks.
+So how to setup crawler scheduler tasks:
 
 1. Add a new Scheduler Task
-2. Select Frequency for the execution
-3. Select the `Execute console commands`
-4. Go to section `Schedulable Command. Save and reopen to define command arguments` at the bottom.
-5. Select e.g. `Crawler:buildQueue` (press save)
-6. Select the options you want to execute the queue with, it's important to check the checkboxes and not only fill in the values.
+2. Select the class :guilabel:`Execute console commands`
+3. Select :guilabel:`Frequency` for the execution
+4. Go to section :guilabel:`Schedulable Command. Save and reopen to define
+   command arguments` at the bottom.
+5. Select e.g. :guilabel:`crawler:buildQueue` (press save)
+6. Select the options you want to execute the queue with, it's important to
+   check the checkboxes and not only fill in the values.
 
-Now you can save and exit, and you scheduler tasks will be running as configured.
+Now you can save and close, and your scheduler tasks will be running as
+configured.
 
-The configured scheduler will look like this:
+The configured task will look like this:
 
-.. image:: /Images/backend_scheduler_record.png
+.. figure:: /Images/backend_scheduler_record.png
+   :alt: Task configuration for building the queue
 
-And after save and exit, you can see what command is executed, it would be the same parameters, you can use when running from cli, see :ref:`executing-the-queue-cli-label`
+   Task configuration for building the queue
 
-.. image:: /Images/backend_scheduler_overview.png
+And after save and close, you can see what command is executed, it would be
+the same parameters, you can use when running from cli,
+see :ref:`executing-the-queue-cli-label`
 
+.. figure:: /Images/backend_scheduler_overview.png
+   :alt: Task in the scheduled tasks overview
 
-
+   Task in the scheduled tasks overview

--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -1,31 +1,23 @@
-﻿
+﻿.. include:: /Includes.txt
 
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
-
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+===============
 Troubleshooting
----------------
+===============
+
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
 
 Problem reading data in Crawler Queue
-'''''''''''''''''''''''''''''''''''''
+=====================================
 
-With the crawler release 9.1.0 we have changed the data stores in crawler queue from serialized to json data.
-If you are experiencing problems with the old data still in your database, you can flush your complete crawler queue
-and the problem should be solved.
+With the crawler release 9.1.0 we have changed the data stores in crawler queue
+from serialized to json data. If you are experiencing problems with the old data
+still in your database, you can flush your complete crawler queue and the
+problem should be solved.
 
-We have build in a `JsonCompatibiityConverter` to ensure that this should not happen, but in case of it run:
+We have build in a `JsonCompatibilityConverter` to ensure that this should not
+happen, but in case of it run:
 
 ::
 
@@ -33,18 +25,21 @@ We have build in a `JsonCompatibiityConverter` to ensure that this should not ha
 
 
 Make Direct Request doesn't work
-''''''''''''''''''''''''''''''''
-If you are using direct request, see :ref:`extension-manager-configuration`, and it doesn't give you any result,
-or that the scheduler tasks stalls.
+================================
 
-It can be because of a faulty configured `TrustedHostPattern`, this can be changed in the `LocalConfiguration.php`.
+If you are using direct request, see :ref:`extension-manager-configuration`,
+and it doesn't give you any result, or that the scheduler tasks stalls.
 
-::
+It can be because of a faulty configured `TrustedHostPattern`, this can be
+changed in the :file:`LocalConfiguration.php`.
+
+.. code-block:: php
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '<your-pattern>';
 
+
 Crawler want process all entries from command line
-''''''''''''''''''''''''''''''''''''''''''''''''''
+==================================================
 
 The crawler won't process all entries at command-line-way. This might
 happened because the php run into an time out, to avoid this you can
@@ -52,28 +47,35 @@ call the crawler like:
 
 ::
 
-   php -d max_execution_time=512 [pathToYourTYPO3Installation-composer-bin-dir]/typo3cms crawler:buildQueue
+   php -d max_execution_time=512 vendor/bin/typo3 crawler:buildQueue
+
 
 Crawler Count is 0 (zero)
-'''''''''''''''''''''''''
+=========================
 
-If you experiences that the crawler queue only adds one url to the queue, you are probably on a new setup,
-or an update from TYPO3 8LTS you might have some migration not executed yet.
+If you experiences that the crawler queue only adds one url to the queue, you
+are probably on a new setup, or an update from TYPO3 8LTS you might have some
+migration not executed yet.
 
-Please check the Upgrade Wizard, and check if the "Introduce URL parts ("slugs") to all existing pages"
-is marked as done, if not you should perform this step.
+Please check the :guilabel:`Upgrade Wizard`, and check if the
+:guilabel:`Introduce URL parts ("slugs") to all existing pages` is marked as
+done, if not you should perform this step.
 
 See related issue: `[BUG] Crawling Depth not respected #464 <https://github.com/AOEpeople/crawler/issues/464>`_
 
 
 Update from older versions
-''''''''''''''''''''''''''
+==========================
 
 If you update the extension from older versions you can run into following error:
 
-::
+.. code-block:: text
 
     SQL error: 'Field 'sys_domain_base_url' doesn't have a default value'
 
-Make sure to delete all unnecessary fields from database tables. You can do this in the backend via "Analyze Database Structure"-Tool or if you have typo3-console installed via command line command "typo3cms database:updateschema".
+Make sure to delete all unnecessary fields from database tables. You can do
+this in the backend via :guilabel:`Analyze Database Structure` tool or if you
+have `TYPO3 Console <https://extensions.typo3.org/extension/typo3_console/>`_
+installed via command line command
+:shell:`vendor/bin/typo3cms database:updateschema`.
 

--- a/Documentation/UseCases/CacheWarmup/Index.rst
+++ b/Documentation/UseCases/CacheWarmup/Index.rst
@@ -1,75 +1,87 @@
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+=============
 Cache warm up
--------------
+=============
 
-To have a website that is fast for the end-user is essential, therefor having a warm cache even before the
-first user hits the newly deployed website, will be beneficial, so how could one achieve this?
+To have a website that is fast for the end-user is essential, therefore having a
+warm cache even before the first user hits the newly deployed website, will be
+beneficial, so how could one achieve this?
 
-The crawler have some command line tools (herafter cli tools) that can be used, during deployments. The cli tools is
-implemented with the `symfony/console` which have been standard in TYPO3 for a while.
+The crawler have some command line tools (hereafter cli tools) that can be used,
+during deployments. The cli tools is implemented with the `symfony/console`
+which have been standard in TYPO3 for a while.
 
 There are 3 commands that can be of you benefit during deployments.
 
-* `vendor/bin/typo3 crawler:flushQueue`
-* `vendor/to/bin/typo3 crawler:buildQueue`
-* `vendor/to/bin/typo3 crawler:processQueue`
+* :shell:`vendor/bin/typo3 crawler:flushQueue`
+* :shell:`vendor/bin/typo3 crawler:buildQueue`
+* :shell:`vendor/bin/typo3 crawler:processQueue`
 
-You can see more on which parameters they take in :ref:`command-controller`, this example will provide suggestion on how you can
-set it up, and you can adjust with additional parameters if you like.
+You can see more on which parameters they take in :ref:`command-controller`,
+this example will provide suggestion on how you can set it up, and you can
+adjust with additional parameters if you like.
 
-First we need a `crawler configuration` these are stored in the Database. You can add it via the backend, see :ref:`backend-configuration-record`.
+.. rst-class:: bignums-xxl
 
-It's is suggested to select the most important pages of the website and add them to a Crawler configuration called e.g. `deployment`
+#. Create crawler configuration
 
-.. image:: /Images/backend_configuration_deployment.png
+   First we need a `crawler configuration` these are stored in the database. You
+   can add it via the backend, see :ref:`backend-configuration-record`.
 
-With this only pages added will be crawled when using this configuration. So how will we execute this from CLI during deployment?
-I don't know which deployment tool you use, but it's not important as long as you can execute shell commands. What would you need to execute?
+   It's suggested to select the most important pages of the website and add
+   them to a Crawler configuration called e.g. `deployment`:
 
-::
+   .. figure:: /Images/backend_configuration_deployment.png
+      :alt: Crawler configuration record
 
-    # Done to make sure the crawler queue is empty, so that we will only crawl important pages.
-    $ vendor/bin/typo3 crawler:flushQueue all
+      Crawler configuration record
 
-    # Now we want to fill the crawler queue,
-    # This will start on page uid 1 with the deployment configuration and depth 99,
-    # --mode exec crawles the pages instantly so we don't need a secondary process for that.
-    $ vendor/bin/typo3 crawler:buildQueue 1 deployment --depth 99 --mode exec
+#. Build the queue
 
-    # Add the rest of the pages to crawler queue and have the processed with the scheduler
-    # --mode queue is default, but it is  added for visibility,
-    # we assume that you have a crawler configuration called default
-    $ vendor/bin/typo3 crawler:buildQueue 1 default --depth 99 --mode queue
+   With this only pages added will be crawled when using this configuration. So
+   how will we execute this from CLI during deployment? I don't know which
+   deployment tool you use, but it's not important as long as you can execute
+   shell commands. What would you need to execute?
+
+   ::
+
+      # Done to make sure the crawler queue is empty, so that we will only crawl important pages.
+      $ vendor/bin/typo3 crawler:flushQueue all
+
+      # Now we want to fill the crawler queue,
+      # This will start on page uid 1 with the deployment configuration and depth 99,
+      # --mode exec crawles the pages instantly so we don't need a secondary process for that.
+      $ vendor/bin/typo3 crawler:buildQueue 1 deployment --depth 99 --mode exec
+
+      # Add the rest of the pages to crawler queue and have the processed with the scheduler
+      # --mode queue is default, but it is  added for visibility,
+      # we assume that you have a crawler configuration called default
+      $ vendor/bin/typo3 crawler:buildQueue 1 default --depth 99 --mode queue
+
+#. Process the queue
+
+   The last step will add the pages to the queue, and you would need a scheduler
+   task setup to have them processed. Go to the :guilabel:`Scheduler` module and
+   do following steps:
+
+   1. Add a new Scheduler Task
+   2. Select the :guilabel:`Execute console commands`
+   3. Select :guilabel:`Frequency` for the execution
+   4. Go to section :guilabel:`Schedulable Command. Save and reopen to define
+      command arguments` at the bottom.
+   5. Select :guilabel:`crawler:processQueue` (press save)
+   6. Select the options you want to execute the queue with, it's important to
+      check the checkboxes and not only fill in the values.
+
+   .. figure:: /Images/backend_scheduler_processqueue.png
+      :alt: Options of the task
+
+      Options of the task
 
 
-The last step will add the pages to the queue, and you would need a scheduler task setup to have them executed. Go to
-the scheduler module and do following steps:
-
-1. Add a new Scheduler Task
-2. Select Frequency for the execution
-3. Select the `Execute console commands`
-4. Go to section `Schedulable Command. Save and reopen to define command arguments` at the bottom.
-5. Select `Crawler:processQueue` (press save)
-6. Select the options you want to execute the queue with, it's important to check the checkboxes and not only fill in the values.
-
-.. image:: /Images/backend_scheduler_processqueue.png
-
-With there steps you will have a website that is faster byt the first visit after a deployment, and the rest of the website
-is crawled automatically shortly after.
+With there steps you will have a website that is faster by the first visit after
+a deployment, and the rest of the website is crawled automatically shortly
+after.
 
 `#HappyCrawling`
-

--- a/Documentation/UseCases/Index.rst
+++ b/Documentation/UseCases/Index.rst
@@ -1,23 +1,14 @@
-.. ==================================================
-.. FOR YOUR INFORMATION
-.. --------------------------------------------------
-.. -*- coding: utf-8 -*- with BOM.
+.. include:: /Includes.txt
 
-.. ==================================================
-.. DEFINE SOME TEXTROLES
-.. --------------------------------------------------
-.. role::   underline
-.. role::   typoscript(code)
-.. role::   ts(typoscript)
-   :class:  typoscript
-.. role::   php(code)
-
-
+=========
 Use cases
----------
-This section is made to show different use cases for the crawler, and what value it can bring by installing it.
-The crawler has transform over the years to have multiple use cases, if you have some that is not listed here, feel free
-to make a PR or Issue on `https://github.com/AOEpeople/crawler <https://github.com/AOEpeople/crawler/>`_.
+=========
+
+This section is made to show different use cases for the crawler, and what value
+it can bring by installing it. The crawler has transformed over the years to
+have multiple use cases. If you have some that is not listed here, feel free
+to make a PR or issue on `https://github.com/AOEpeople/crawler
+<https://github.com/AOEpeople/crawler/>`_.
 
 .. toctree::
    :maxdepth: 5


### PR DESCRIPTION
- Remove "coding: utf-8 -*- with BOM" -> in practise it is without BOM
- Use Includes.txt on every page to avoid doubling roles
- Structure headers correctly
- Use "figure" with caption where appropriate
- Use "vendor/bin/typo3" throughout the document for unity
- Adjust .editoconfig: Show line length at 80 chars (e.g. in PhpStorm) and define indentation at 3 chars (like in core documentation)
- git-ignore generated documentation