### PR TITLE
[TASK] Configure commands in Services.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * Update specific doktypes for skipping page [@brotkrueml](https://github.com/brotkrueml)
+* Configure commands in Services.yaml for TYPO3 v10 [@brotkrueml](https://github.com/brotkrueml)
 * Tests for BackendModule
 
 ### Fixed

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -6,6 +6,10 @@ use AOE\Crawler\Command\BuildQueueCommand;
 use AOE\Crawler\Command\FlushQueueCommand;
 use AOE\Crawler\Command\ProcessQueueCommand;
 
+// This file can be removed when compatibility with TYPO3 v9 is dropped.
+// The configuration can now also be found in Configuration/Services.yaml
+// for TYPO3 v10+!
+
 return [
     'crawler:buildQueue' => [
         'class' => BuildQueueCommand::class,

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,23 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    AOE\Crawler\:
+        resource: '../Classes/*'
+
+    AOE\Crawler\Command\BuildQueueCommand:
+        tags:
+            - name: 'console.command'
+              command: 'crawler:buildQueue'
+
+    AOE\Crawler\Command\FlushQueueCommand:
+        tags:
+            - name: 'console.command'
+              command: 'crawler:flushQueue'
+
+    AOE\Crawler\Command\ProcessQueueCommand:
+        tags:
+            - name: 'console.command'
+              command: 'crawler:processQueue'


### PR DESCRIPTION
In TYPO3 v10+ commands are configured in Configuration/Services.yaml with dependency
injection tags. To keep backward compatibility with TYPO3 v9 the old configuration
in Configuration/Commands.php is kept.

This avoids deprecation notices in TYPO3 v10 and makes the configuration future-proof.

See also: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Feature-89139-AddDependencyInjectionSupportForConsoleCommands.html