### PR TITLE
[TASK] Add resname attribute to trans-unit tags in XLF files

### DIFF
--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -1,158 +1,158 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.0">
-    <file source-language="en" datatype="plaintext" original="messages" date="2016-11-04T16:17:39Z" product-name="crawler">
+    <file source-language="en" datatype="plaintext" original="EXT:crawler/Resources/Private/Language/Backend.xlf" date="2016-11-04T16:17:39Z" product-name="crawler">
         <header/>
         <body>
-            <trans-unit id="moduleFunction.tx_crawler_modfunc1">
+            <trans-unit id="moduleFunction.tx_crawler_modfunc1" resname="moduleFunction.tx_crawler_modfunc1">
                 <source>Site Crawler</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration">
+            <trans-unit id="tx_crawler_configuration" resname="tx_crawler_configuration">
                 <source>Crawler Configuration</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.name">
+            <trans-unit id="tx_crawler_configuration.name" resname="tx_crawler_configuration.name">
                 <source>Name</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.crawling_protocol">
+            <trans-unit id="tx_crawler_configuration.crawling_protocol" resname="tx_crawler_configuration.crawling_protocol">
                 <source>Protocol for crawling</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.crawling_protocol.http">
+            <trans-unit id="tx_crawler_configuration.crawling_protocol.http" resname="tx_crawler_configuration.crawling_protocol.http">
                 <source>Force HTTP for all pages</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.crawling_protocol.page_config">
+            <trans-unit id="tx_crawler_configuration.crawling_protocol.page_config" resname="tx_crawler_configuration.crawling_protocol.page_config">
                 <source>Keeps page configured protocol</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.crawling_protocol.https">
+            <trans-unit id="tx_crawler_configuration.crawling_protocol.https" resname="tx_crawler_configuration.crawling_protocol.https">
                 <source>Force HTTPS for all pages</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.processing_instruction_filter">
+            <trans-unit id="tx_crawler_configuration.processing_instruction_filter" resname="tx_crawler_configuration.processing_instruction_filter">
                 <source>Processing instruction filter</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.processing_instruction_filter.description">
+            <trans-unit id="tx_crawler_configuration.processing_instruction_filter.description" resname="tx_crawler_configuration.processing_instruction_filter.description">
                 <source>List of processing instructions to send for the request. Processing instructions are necessary for the request to perform any meaningful action, since they activate third party activity.</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.processing_instruction_parameters_ts">
+            <trans-unit id="tx_crawler_configuration.processing_instruction_parameters_ts" resname="tx_crawler_configuration.processing_instruction_parameters_ts">
                 <source>Processing instruction parameters</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.configuration">
+            <trans-unit id="tx_crawler_configuration.configuration" resname="tx_crawler_configuration.configuration">
                 <source>Configuration</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.base_url">
+            <trans-unit id="tx_crawler_configuration.base_url" resname="tx_crawler_configuration.base_url">
                 <source>Base URL</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.base_url.description">
+            <trans-unit id="tx_crawler_configuration.base_url.description" resname="tx_crawler_configuration.base_url.description">
                 <source>Leave empty for fetching the base URL from the Site Configuration.</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.pidsonly">
+            <trans-unit id="tx_crawler_configuration.pidsonly" resname="tx_crawler_configuration.pidsonly">
                 <source>Pids only</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.pidsonly.description">
+            <trans-unit id="tx_crawler_configuration.pidsonly.description" resname="tx_crawler_configuration.pidsonly.description">
                 <source>List of page IDs to limit this configuration to.</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.begroups">
+            <trans-unit id="tx_crawler_configuration.begroups" resname="tx_crawler_configuration.begroups">
                 <source>Restrict access to</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.begroups.description">
+            <trans-unit id="tx_crawler_configuration.begroups.description" resname="tx_crawler_configuration.begroups.description">
                 <source>Restrict access to this configuration record to selected backend user groups. Empty means no restriction is set.</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.fegroups">
+            <trans-unit id="tx_crawler_configuration.fegroups" resname="tx_crawler_configuration.fegroups">
                 <source>Crawl with FE user groups</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.fegroups.description">
+            <trans-unit id="tx_crawler_configuration.fegroups.description" resname="tx_crawler_configuration.fegroups.description">
                 <source>Frontend user groups to set for the request.</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.exclude">
+            <trans-unit id="tx_crawler_configuration.exclude" resname="tx_crawler_configuration.exclude">
                 <source>Exclude pages</source>
             </trans-unit>
-            <trans-unit id="tx_crawler_configuration.exclude.description">
+            <trans-unit id="tx_crawler_configuration.exclude.description" resname="tx_crawler_configuration.exclude.description">
                 <source>Comma separated list of page IDs which should not be crawled.</source>
             </trans-unit>
-            <trans-unit id="crawler_im.name">
+            <trans-unit id="crawler_im.name" resname="crawler_im.name">
                 <source>Crawler queue</source>
             </trans-unit>
-            <trans-unit id="crawler_im.description">
+            <trans-unit id="crawler_im.description" resname="crawler_im.description">
                 <source>Running the crawler queue process to collect the relevant entries.</source>
             </trans-unit>
-            <trans-unit id="crawler_im.startPage">
+            <trans-unit id="crawler_im.startPage" resname="crawler_im.startPage">
                 <source>Start page</source>
             </trans-unit>
-            <trans-unit id="crawler_im.depth">
+            <trans-unit id="crawler_im.depth" resname="crawler_im.depth">
                 <source>Depth</source>
             </trans-unit>
-            <trans-unit id="crawler_im.invalidStartPage">
+            <trans-unit id="crawler_im.invalidStartPage" resname="crawler_im.invalidStartPage">
                 <source>Start page must be a positive integer!</source>
             </trans-unit>
-            <trans-unit id="crawler_im.invalidDepth">
+            <trans-unit id="crawler_im.invalidDepth" resname="crawler_im.invalidDepth">
                 <source>There is no depth set, please set it to an value!</source>
             </trans-unit>
-            <trans-unit id="crawler_im.conf">
+            <trans-unit id="crawler_im.conf" resname="crawler_im.conf">
                 <source>Configuration records</source>
             </trans-unit>
-            <trans-unit id="crawler_im.invalidConfiguration">
+            <trans-unit id="crawler_im.invalidConfiguration" resname="crawler_im.invalidConfiguration">
                 <source>There is no configuration record selected, please choose at least one or more!</source>
             </trans-unit>
-            <trans-unit id="crawler_im.timeOut">
+            <trans-unit id="crawler_im.timeOut" resname="crawler_im.timeOut">
                 <source>Time out</source>
             </trans-unit>
-            <trans-unit id="crawler_im.sleepTime">
+            <trans-unit id="crawler_im.sleepTime" resname="crawler_im.sleepTime">
                 <source>Sleep time</source>
             </trans-unit>
-            <trans-unit id="crawler_im.invalidTimeOut">
+            <trans-unit id="crawler_im.invalidTimeOut" resname="crawler_im.invalidTimeOut">
                 <source>The time out must be a positive integer!</source>
             </trans-unit>
-            <trans-unit id="crawler_im.invalidSleepTime">
+            <trans-unit id="crawler_im.invalidSleepTime" resname="crawler_im.invalidSleepTime">
                 <source>The sleep time must be a positive integer!</source>
             </trans-unit>
-            <trans-unit id="crawler_im.sleepAfterFinish">
+            <trans-unit id="crawler_im.sleepAfterFinish" resname="crawler_im.sleepAfterFinish">
                 <source>Sleep after finish</source>
             </trans-unit>
-            <trans-unit id="crawler_im.invalidSleepAfterFinish">
+            <trans-unit id="crawler_im.invalidSleepAfterFinish" resname="crawler_im.invalidSleepAfterFinish">
                 <source>The sleep after finish must be a positive integer!</source>
             </trans-unit>
-            <trans-unit id="crawler_im.countInARun">
+            <trans-unit id="crawler_im.countInARun" resname="crawler_im.countInARun">
                 <source>Count in a run</source>
             </trans-unit>
-            <trans-unit id="crawler_im.invalidCountInARun">
+            <trans-unit id="crawler_im.invalidCountInARun" resname="crawler_im.invalidCountInARun">
                 <source>The count in a run must be a positive integer!</source>
             </trans-unit>
 
-            <trans-unit id="crawler_crawlMultiProcess.name">
+            <trans-unit id="crawler_crawlMultiProcess.name" resname="crawler_crawlMultiProcess.name">
                 <source>Crawler Run Multi Process</source>
             </trans-unit>
 
-            <trans-unit id="crawler_crawl.name">
+            <trans-unit id="crawler_crawl.name" resname="crawler_crawl.name">
                 <source>Crawler Run</source>
             </trans-unit>
-            <trans-unit id="crawler_crawl.description">
+            <trans-unit id="crawler_crawl.description" resname="crawler_crawl.description">
                 <source>Running the crawler to extension to process it's queue-entries.</source>
             </trans-unit>
 
-            <trans-unit id="crawler_flush.name">
+            <trans-unit id="crawler_flush.name" resname="crawler_flush.name">
                 <source>Crawler Queue Flush</source>
             </trans-unit>
-            <trans-unit id="crawler_flush.description">
+            <trans-unit id="crawler_flush.description" resname="crawler_flush.description">
                 <source>Cleanup the crawler queue and remove unwanted or finished entries.</source>
             </trans-unit>
-            <trans-unit id="crawler_flush.mode">
+            <trans-unit id="crawler_flush.mode" resname="crawler_flush.mode">
                 <source>Flush mode</source>
             </trans-unit>
-            <trans-unit id="crawler_flush.modeAll">
+            <trans-unit id="crawler_flush.modeAll" resname="crawler_flush.modeAll">
                 <source>Flush all entries</source>
             </trans-unit>
-            <trans-unit id="crawler_flush.modeFinished">
+            <trans-unit id="crawler_flush.modeFinished" resname="crawler_flush.modeFinished">
                 <source>Flush finished entries</source>
             </trans-unit>
-            <trans-unit id="crawler_flush.modePending">
+            <trans-unit id="crawler_flush.modePending" resname="crawler_flush.modePending">
                 <source>Flush pending entries</source>
             </trans-unit>
 
-            <trans-unit id="crawler_processCleanup.name">
+            <trans-unit id="crawler_processCleanup.name" resname="crawler_processCleanup.name">
                 <source>Remove Processes</source>
             </trans-unit>
-            <trans-unit id="crawler_processCleanup.description">
+            <trans-unit id="crawler_processCleanup.description" resname="crawler_processCleanup.description">
                 <source>Remove Orphan processes and processes that are older than one hour</source>
             </trans-unit>
 
-            <trans-unit id="contextMenu.label">
+            <trans-unit id="contextMenu.label" resname="contextMenu.label">
                 <source>Crawl</source>
             </trans-unit>
         </body>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,274 +1,274 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.0">
-	<file source-language="en" datatype="plaintext" original="messages" date="2020-04-15T15:00:00Z"
+	<file source-language="en" datatype="plaintext" original="EXT:crawler/Resources/Private/Language/locallang.xlf" date="2020-04-15T15:00:00Z"
 		  product-name="crawler">
 		<header/>
 		<body>
-			<trans-unit id="title">
+			<trans-unit id="title" resname="title">
 				<source>Site Crawler</source>
 			</trans-unit>
-			<trans-unit id="labels.start">
+			<trans-unit id="labels.start" resname="labels.start">
 				<source>Start Crawling</source>
 			</trans-unit>
-			<trans-unit id="labels.log">
+			<trans-unit id="labels.log" resname="labels.log">
 				<source>Crawler log</source>
 			</trans-unit>
-			<trans-unit id="labels.multiprocess">
+			<trans-unit id="labels.multiprocess" resname="labels.multiprocess">
 				<source>Crawling Processes</source>
 			</trans-unit>
-			<trans-unit id="labels.all">
+			<trans-unit id="labels.all" resname="labels.all">
 				<source>All</source>
 			</trans-unit>
-			<trans-unit id="labels.pending">
+			<trans-unit id="labels.pending" resname="labels.pending">
 				<source>Pending</source>
 			</trans-unit>
-			<trans-unit id="labels.finished">
+			<trans-unit id="labels.finished" resname="labels.finished">
 				<source>Finished</source>
 			</trans-unit>
-			<trans-unit id="labels.noPageSelected">
+			<trans-unit id="labels.noPageSelected" resname="labels.noPageSelected">
 				<source>Please select a page in the pagetree</source>
 			</trans-unit>
-			<trans-unit id="labels.noConfigSelected">
+			<trans-unit id="labels.noConfigSelected" resname="labels.noConfigSelected">
 				<source>Please select at least one configuration</source>
 			</trans-unit>
-			<trans-unit id="labels.configuration">
+			<trans-unit id="labels.configuration" resname="labels.configuration">
 				<source>Crawl configuration</source>
 			</trans-unit>
-			<trans-unit id="labels.triggerUpdate">
+			<trans-unit id="labels.triggerUpdate" resname="labels.triggerUpdate">
 				<source>Update</source>
 			</trans-unit>
-			<trans-unit id="labels.triggerCrawl">
+			<trans-unit id="labels.triggerCrawl" resname="labels.triggerCrawl">
 				<source>Crawl URLs</source>
 			</trans-unit>
-			<trans-unit id="labels.triggerDownload">
+			<trans-unit id="labels.triggerDownload" resname="labels.triggerDownload">
 				<source>Download URLs</source>
 			</trans-unit>
-			<trans-unit id="labels.continue">
+			<trans-unit id="labels.continue" resname="labels.continue">
 				<source>Continue</source>
 			</trans-unit>
-			<trans-unit id="labels.continueinlog">
+			<trans-unit id="labels.continueinlog" resname="labels.continueinlog">
 				<source>Continue and show Log</source>
 			</trans-unit>
-			<trans-unit id="labels.count">
+			<trans-unit id="labels.count" resname="labels.count">
 				<source>Count</source>
 			</trans-unit>
-			<trans-unit id="labels.time">
+			<trans-unit id="labels.time" resname="labels.time">
 				<source>Time</source>
 			</trans-unit>
-			<trans-unit id="labels.curtime">
+			<trans-unit id="labels.curtime" resname="labels.curtime">
 				<source>Current server time</source>
 			</trans-unit>
-			<trans-unit id="labels.submitted">
+			<trans-unit id="labels.submitted" resname="labels.submitted">
 				<source>URLs submitted</source>
 			</trans-unit>
-			<trans-unit id="labels.depth">
+			<trans-unit id="labels.depth" resname="labels.depth">
 				<source>Depth</source>
 			</trans-unit>
-			<trans-unit id="labels.configurations">
+			<trans-unit id="labels.configurations" resname="labels.configurations">
 				<source>Configurations</source>
 			</trans-unit>
-			<trans-unit id="labels.scheduled">
+			<trans-unit id="labels.scheduled" resname="labels.scheduled">
 				<source>Scheduled</source>
 			</trans-unit>
-			<trans-unit id="labels.pagetitle">
+			<trans-unit id="labels.pagetitle" resname="labels.pagetitle">
 				<source>Page title</source>
 			</trans-unit>
-			<trans-unit id="labels.key">
+			<trans-unit id="labels.key" resname="labels.key">
 				<source>Key</source>
 			</trans-unit>
-			<trans-unit id="labels.parametercfg">
+			<trans-unit id="labels.parametercfg" resname="labels.parametercfg">
 				<source>Parameter Cfg</source>
 			</trans-unit>
-			<trans-unit id="labels.values">
+			<trans-unit id="labels.values" resname="labels.values">
 				<source>Values Expanded</source>
 			</trans-unit>
-			<trans-unit id="labels.url">
+			<trans-unit id="labels.url" resname="labels.url">
 				<source>URL</source>
 			</trans-unit>
-			<trans-unit id="labels.urls">
+			<trans-unit id="labels.urls" resname="labels.urls">
 				<source>URLs</source>
 			</trans-unit>
-			<trans-unit id="labels.options">
+			<trans-unit id="labels.options" resname="labels.options">
 				<source>Options</source>
 			</trans-unit>
-			<trans-unit id="labels.parameters">
+			<trans-unit id="labels.parameters" resname="labels.parameters">
 				<source>Parameters</source>
 			</trans-unit>
-			<trans-unit id="labels.back">
+			<trans-unit id="labels.back" resname="labels.back">
 				<source>Back</source>
 			</trans-unit>
-			<trans-unit id="labels.reloadlist">
+			<trans-unit id="labels.reloadlist" resname="labels.reloadlist">
 				<source>Reload list</source>
 			</trans-unit>
-			<trans-unit id="labels.downloadcsv">
+			<trans-unit id="labels.downloadcsv" resname="labels.downloadcsv">
 				<source>Download entries as CSV</source>
 			</trans-unit>
-			<trans-unit id="labels.flushvisiblequeue">
+			<trans-unit id="labels.flushvisiblequeue" resname="labels.flushvisiblequeue">
 				<source>Flush visible entries</source>
 			</trans-unit>
-			<trans-unit id="labels.flushfullqueue">
+			<trans-unit id="labels.flushfullqueue" resname="labels.flushfullqueue">
 				<source>Flush entire queue</source>
 			</trans-unit>
-			<trans-unit id="labels.confirmyouresure">
+			<trans-unit id="labels.confirmyouresure" resname="labels.confirmyouresure">
 				<source>Are you sure?</source>
 			</trans-unit>
-			<trans-unit id="labels.setid">
+			<trans-unit id="labels.setid" resname="labels.setid">
 				<source>Set ID</source>
 			</trans-unit>
-			<trans-unit id="labels.qid">
+			<trans-unit id="labels.qid" resname="labels.qid">
 				<source>Queue id</source>
 			</trans-unit>
-			<trans-unit id="labels.resultlog">
+			<trans-unit id="labels.resultlog" resname="labels.resultlog">
 				<source>Result Log</source>
 			</trans-unit>
-			<trans-unit id="labels.scheduledtime">
+			<trans-unit id="labels.scheduledtime" resname="labels.scheduledtime">
 				<source>Scheduled</source>
 			</trans-unit>
-			<trans-unit id="labels.runtime">
+			<trans-unit id="labels.runtime" resname="labels.runtime">
 				<source>Run-time</source>
 			</trans-unit>
-			<trans-unit id="labels.status">
+			<trans-unit id="labels.status" resname="labels.status">
 				<source>Status</source>
 			</trans-unit>
-			<trans-unit id="labels.groups">
+			<trans-unit id="labels.groups" resname="labels.groups">
 				<source>Groups</source>
 			</trans-unit>
-			<trans-unit id="labels.procinstr">
+			<trans-unit id="labels.procinstr" resname="labels.procinstr">
 				<source>Proc. Instr.</source>
 			</trans-unit>
-			<trans-unit id="labels.newprocess">
+			<trans-unit id="labels.newprocess" resname="labels.newprocess">
 				<source>New process has been started, refresh to monitor the state</source>
 			</trans-unit>
-			<trans-unit id="labels.newprocesserror">
+			<trans-unit id="labels.newprocesserror" resname="labels.newprocesserror">
 				<source>Error while starting process</source>
 			</trans-unit>
-			<trans-unit id="labels.time.now">
+			<trans-unit id="labels.time.now" resname="labels.time.now">
 				<source>Now</source>
 			</trans-unit>
-			<trans-unit id="labels.time.midnight">
+			<trans-unit id="labels.time.midnight" resname="labels.time.midnight">
 				<source>Midnight</source>
 			</trans-unit>
-			<trans-unit id="labels.time.4am">
+			<trans-unit id="labels.time.4am" resname="labels.time.4am">
 				<source>4 AM</source>
 			</trans-unit>
-			<trans-unit id="labels.display">
+			<trans-unit id="labels.display" resname="labels.display">
 				<source>Display</source>
 			</trans-unit>
-			<trans-unit id="labels.showresultlog">
+			<trans-unit id="labels.showresultlog" resname="labels.showresultlog">
 				<source>Show Result Log</source>
 			</trans-unit>
-			<trans-unit id="labels.showfevars">
+			<trans-unit id="labels.showfevars" resname="labels.showfevars">
 				<source>Show FE Vars</source>
 			</trans-unit>
-			<trans-unit id="labels.noentries">
+			<trans-unit id="labels.noentries" resname="labels.noentries">
 				<source>No entries</source>
 			</trans-unit>
-			<trans-unit id="labels.immediate">
+			<trans-unit id="labels.immediate" resname="labels.immediate">
 				<source>immediate</source>
 			</trans-unit>
-			<trans-unit id="labels.generalinformation">
+			<trans-unit id="labels.generalinformation" resname="labels.generalinformation">
 				<source>General Information</source>
 			</trans-unit>
-			<trans-unit id="labels.pendingoverview">
+			<trans-unit id="labels.pendingoverview" resname="labels.pendingoverview">
 				<source>Pending Entries (assigned / overall)</source>
 			</trans-unit>
-			<trans-unit id="labels.processcount">
+			<trans-unit id="labels.processcount" resname="labels.processcount">
 				<source>Processes count (running / max)</source>
 			</trans-unit>
-			<trans-unit id="labels.clipath">
+			<trans-unit id="labels.clipath" resname="labels.clipath">
 				<source>CLI-Path</source>
 			</trans-unit>
-			<trans-unit id="labels.processstates">
+			<trans-unit id="labels.processstates" resname="labels.processstates">
 				<source>Process States</source>
 			</trans-unit>
-			<trans-unit id="labels.state">
+			<trans-unit id="labels.state" resname="labels.state">
 				<source>State</source>
 			</trans-unit>
-			<trans-unit id="labels.processid">
+			<trans-unit id="labels.processid" resname="labels.processid">
 				<source>Id</source>
 			</trans-unit>
-			<trans-unit id="labels.time.first">
+			<trans-unit id="labels.time.first" resname="labels.time.first">
 				<source>Time first item</source>
 			</trans-unit>
-			<trans-unit id="labels.time.last">
+			<trans-unit id="labels.time.last" resname="labels.time.last">
 				<source>Time last item</source>
 			</trans-unit>
-			<trans-unit id="labels.time.duration">
+			<trans-unit id="labels.time.duration" resname="labels.time.duration">
 				<source>Runtime</source>
 			</trans-unit>
-			<trans-unit id="labels.ttl">
+			<trans-unit id="labels.ttl" resname="labels.ttl">
 				<source>TTL</source>
 			</trans-unit>
-			<trans-unit id="labels.status.current">
+			<trans-unit id="labels.status.current" resname="labels.status.current">
 				<source>Processed</source>
 			</trans-unit>
-			<trans-unit id="labels.status.initial">
+			<trans-unit id="labels.status.initial" resname="labels.status.initial">
 				<source>Initially assigned</source>
 			</trans-unit>
-			<trans-unit id="labels.status.finally">
+			<trans-unit id="labels.status.finally" resname="labels.status.finally">
 				<source>Finally assigned</source>
 			</trans-unit>
-			<trans-unit id="labels.status.progress">
+			<trans-unit id="labels.status.progress" resname="labels.status.progress">
 				<source>Progress</source>
 			</trans-unit>
-			<trans-unit id="labels.process.running">
+			<trans-unit id="labels.process.running" resname="labels.process.running">
 				<source>Process running</source>
 			</trans-unit>
-			<trans-unit id="labels.process.success">
+			<trans-unit id="labels.process.success" resname="labels.process.success">
 				<source>Process completed successfully</source>
 			</trans-unit>
-			<trans-unit id="labels.process.cancelled">
+			<trans-unit id="labels.process.cancelled" resname="labels.process.cancelled">
 				<source>Process was cancelled</source>
 			</trans-unit>
-			<trans-unit id="labels.refresh">
+			<trans-unit id="labels.refresh" resname="labels.refresh">
 				<source>Refresh</source>
 			</trans-unit>
-			<trans-unit id="labels.disablecrawling">
+			<trans-unit id="labels.disablecrawling" resname="labels.disablecrawling">
 				<source>Stop all processes and disable crawling</source>
 			</trans-unit>
-			<trans-unit id="labels.enablecrawling">
+			<trans-unit id="labels.enablecrawling" resname="labels.enablecrawling">
 				<source>Enable crawling</source>
 			</trans-unit>
-			<trans-unit id="labels.show.running">
+			<trans-unit id="labels.show.running" resname="labels.show.running">
 				<source>Show only running processes</source>
 			</trans-unit>
-			<trans-unit id="labels.show.all">
+			<trans-unit id="labels.show.all" resname="labels.show.all">
 				<source>Show finished and terminated processes</source>
 			</trans-unit>
-			<trans-unit id="labels.process.add">
+			<trans-unit id="labels.process.add" resname="labels.process.add">
 				<source>Add process</source>
 			</trans-unit>
-			<trans-unit id="time.detailed">
+			<trans-unit id="time.detailed" resname="time.detailed">
 				<source>d-m-y H:i:s</source>
 			</trans-unit>
-			<trans-unit id="labels.itemsPerPage.5">
+			<trans-unit id="labels.itemsPerPage.5" resname="labels.itemsPerPage.5">
 				<source>limit to 5</source>
 			</trans-unit>
-			<trans-unit id="labels.itemsPerPage.10">
+			<trans-unit id="labels.itemsPerPage.10" resname="labels.itemsPerPage.10">
 				<source>limit to 10</source>
 			</trans-unit>
-			<trans-unit id="labels.itemsPerPage.50">
+			<trans-unit id="labels.itemsPerPage.50" resname="labels.itemsPerPage.50">
 				<source>limit to 50</source>
 			</trans-unit>
-			<trans-unit id="labels.itemsPerPage.0">
+			<trans-unit id="labels.itemsPerPage.0" resname="labels.itemsPerPage.0">
 				<source>no limit</source>
 			</trans-unit>
-			<trans-unit id="labels.itemsPerPage">
+			<trans-unit id="labels.itemsPerPage" resname="labels.itemsPerPage">
 				<source>Items per page</source>
 			</trans-unit>
-			<trans-unit id="message.noBeUserAvailable">
+			<trans-unit id="message.noBeUserAvailable" resname="message.noBeUserAvailable">
 				<source>There is no be_user "_cli_crawler" available!</source>
 			</trans-unit>
-			<trans-unit id="message.noPhpForkAvailable">
+			<trans-unit id="message.noPhpForkAvailable" resname="message.noPhpForkAvailable">
 				<source>There is no PHP method "popen" available!</source>
 			</trans-unit>
-			<trans-unit id="message.beUserIsAdmin">
+			<trans-unit id="message.beUserIsAdmin" resname="message.beUserIsAdmin">
 				<source>The be_user "_cli_crawler" is not allowed to have admin rights!</source>
 			</trans-unit>
-			<trans-unit id="message.canNotExportEmptyQueueToCsvText">
+			<trans-unit id="message.canNotExportEmptyQueueToCsvText" resname="message.canNotExportEmptyQueueToCsvText">
 				<source>An empty queue can not be exported to CSV.</source>
 			</trans-unit>
-			<trans-unit id="message.phpBinaryNotFound">
+			<trans-unit id="message.phpBinaryNotFound" resname="message.phpBinaryNotFound">
 				<source>No php binary found in '%s'. Please update value for 'phpPath' in crawler extension setup.
 				</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_csh_tx_crawler_configuration.xlf
+++ b/Resources/Private/Language/locallang_csh_tx_crawler_configuration.xlf
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
-    <file t3:id="1509961542" source-language="en" datatype="plaintext" original="messages" date="2017-11-06T10:46:00Z" product-name="crawler">
+    <file t3:id="1509961542" source-language="en" datatype="plaintext" original="EXT:crawler/Resources/Private/Language/locallang_csh_tx_crawler_configuration.xlf" date="2017-11-06T10:46:00Z" product-name="crawler">
         <header/>
         <body>
-            <trans-unit id="root_template_pid.description">
+            <trans-unit id="root_template_pid.description" resname="root_template_pid.description">
                 <source>Page Id the crawler will use for initializing the TSFE (required)</source>
             </trans-unit>
-            <trans-unit id="root_template_pid.details" xml:space="preserve">
+            <trans-unit id="root_template_pid.details" resname="root_template_pid.details" xml:space="preserve">
                 <source>When crawling a page directly fom the TYPO3 backend, e.g. by using the "read" functionality of the "Crawler Log" module, the selected page id will be used to initialize the frontend rendering.
                 Access to the selected page &lt;strong&gt;MUST NOT&lt;/strong&gt; be restricted; crawling will fail otherwise.</source>
             </trans-unit>


### PR DESCRIPTION
## Description

Crowdin doesn't show the information stored in the attribute "id".
If it should be visible, the attribute must be duplicated using
"resname".

find Resources/Private/Language/ -name '*.xlf' -exec sed -i -e \
    '/resname/!s/\(<trans-unit id="\)\([^"]*\)"/\1\2" resname="\2"/' \
    '{}' +

Additionally, the attribute "original" is filled with the path of the translation
file instead of dummy value "messages". This string is also shown in Crowdin
and helps users while translating.

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
