### PR TITLE
[BUGFIX] Load crawler initialization before tsfe rendering preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog TYPO3 Crawler
 
-## [Unreleased]
+## Crawler 9.0.3-dev
+Released:
+
 ### Added
 * Added more information into [CONTRIBUTING.md](CONTRIBUTING.md) about development using container
+
+### Changed
+* Load crawler initialization before tsfe rendering preparation
 
 ## Crawler 9.0.2
 Crawler 9.0.2 was released on July 13th, 2020

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -22,7 +22,7 @@ return [
                 'typo3/cms-frontend/tsfe',
             ],
             'before' => [
-                'typo3/cms-frontend/output-compression',
+                'typo3/cms-frontend/prepare-tsfe-rendering',
             ],
         ],
     ],


### PR DESCRIPTION
In #527 the position of the crawler initialisation has changed to before `typo3/cms-frontend/output-compression`.  
In my installation this is too late and no indexing will be performed for cached pages.

The initialisation must be performed before `typo3/cms-frontend/prepare-tsfe-rendering`. 

At the `typo3/cms-frontend/prepare-tsfe-rendering` middleware the nocache checks are performed and the indexed_search TSFE hook to disable the caching kicks in. 

indexed_search needs the crawler initialisation to disable the cache for the request at this point