### PR TITLE
[DOCS] Use "ddev xdebug on" command to activate xdebug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,9 @@ Username/password: `admin`/`password`
 And start working.
 
 **INFO**
-xdebug is disable as default, to speed up the devbox when xdebug isn't needed.
+xdebug is disabled as default, to speed up the devbox when xdebug isn't needed.
 
-This can be activated in `.devbox/.ddev/config.yaml` and by `ddev restart` afterwards.
+This can be activated with `ddev xdebug on`.
 
 #### Running tests without local development environment
 If you don't have `php` and/or `composer` installed on your host machine,


### PR DESCRIPTION
## Description

Xdebug can be enabled with a ddev command on-the-fly. This is now reflected in the Contributing documentation.

**I have**

- [ ] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
