### PR TITLE
[BUGFIX] Make sure PageUid added with ExcludeString is kept as integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 * Frontend User initialization with UserGroups for crawling protected pages
+* Making sure PageUid added with ExcludeString is kept as integers
 
 ## Crawler 9.1.0
 Crawler 9.1.0 was released on August 2nd, 2020

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -1400,7 +1400,7 @@ class CrawlerController implements LoggerAwareInterface
                         $depth = (stristr($excludePart, '+')) ? 99 : 0;
                     }
 
-                    $pidList[] = $pid;
+                    $pidList[] = (int) $pid;
 
                     if ($depth > 0) {
                         if (empty($treeCache[$pid][$depth])) {
@@ -1410,7 +1410,7 @@ class CrawlerController implements LoggerAwareInterface
                         }
 
                         foreach ($treeCache[$pid][$depth] as $data) {
-                            $pidList[] = $data['row']['uid'];
+                            $pidList[] = (int) $data['row']['uid'];
                         }
                     }
                 }

--- a/Tests/Functional/Controller/CrawlerControllerTest.php
+++ b/Tests/Functional/Controller/CrawlerControllerTest.php
@@ -272,6 +272,23 @@ class CrawlerControllerTest extends FunctionalTestCase
 
     /**
      * @test
+     */
+    public function expandExcludeStringReturnsArraysOfIntegers(): void
+    {
+        $GLOBALS['BE_USER'] = $this->getMockBuilder(BackendUserAuthentication::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['isAdmin', 'getTSConfig', 'getPagePermsClause', 'isInWebMount', 'backendCheckLogin'])
+            ->getMock();
+
+        $excludeStringArray = $this->subject->expandExcludeString('1,2,4,6,8');
+
+        foreach ($excludeStringArray as $excluded) {
+            self::assertIsInt($excluded);
+        }
+    }
+
+    /**
+     * @test
      * @dataProvider getUrlFromPageAndQueryParametersDataProvider
      */
     public function getUrlFromPageAndQueryParameters(int $pageId, string $queryString, ?string $alternativeBaseUrl, int $httpsOrHttp, UriInterface $expected): void


### PR DESCRIPTION
## Description

This makes sure that PageUid added with excludeStrings are kept as Integers.

Resolves: #625

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
