### PR TITLE
[BUGFIX] Switched to GeneralUtility::makeInstance for ProcessRepository and QueueRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 * Frontend User initialization with UserGroups for crawling protected pages
 * Making sure PageUid added with ExcludeString is kept as integers
+* Instatiation of ProcessRepository and QueueRepository change to GeneralUtility::makeInstance
 
 ## Crawler 9.1.0
 Crawler 9.1.0 was released on August 2nd, 2020

--- a/Classes/Api/CrawlerApi.php
+++ b/Classes/Api/CrawlerApi.php
@@ -280,7 +280,7 @@ class CrawlerApi
      */
     public function getActiveProcessesCount(): int
     {
-        $processRepository = new ProcessRepository();
+        $processRepository = GeneralUtility::makeInstance(ProcessRepository::class);
         return $processRepository->findAllActive()->count();
     }
 

--- a/Classes/Backend/BackendModule.php
+++ b/Classes/Backend/BackendModule.php
@@ -764,8 +764,8 @@ class BackendModule
             MessageUtility::addErrorMessage($e->getMessage());
         }
 
-        $processRepository = new ProcessRepository();
-        $queueRepository = new QueueRepository();
+        $processRepository = GeneralUtility::makeInstance(ProcessRepository::class);
+        $queueRepository = GeneralUtility::makeInstance(QueueRepository::class);
 
         $mode = $this->pObj->MOD_SETTINGS['processListMode'];
         if ($mode === 'simple') {


### PR DESCRIPTION
This PR fixed the initiation of ProcessRepository and QueueRepository, switching from new to GeneralUtiltiy::makeInstance()

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
