### PR TITLE
[FEATURE] Add progress bar to BuildQueueCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 ### Deprecated
 
 ### Changed
-* UrlService->getUrlFromPageAndQueryParameters() moved from CrawlerController
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog TYPO3 Crawler
 
+## Crawler 9.1.2-dev
+
+### Added
+* Progress bar to the `crawler:buildQueue` command output when using with `--mode exec`
+
+### Deprecated
+
+### Changed
+* UrlService->getUrlFromPageAndQueryParameters() moved from CrawlerController
+
+### Fixed
+
 ## Crawler 9.1.1
 Crawler 9.1.1 was released on October 17th, 2020
 

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -26,6 +26,7 @@ use AOE\Crawler\Domain\Model\Reason;
 use AOE\Crawler\Domain\Repository\QueueRepository;
 use AOE\Crawler\Utility\SignalSlotUtility;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -103,11 +104,11 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
      * Examples:
      *
      * --- Re-cache pages from page 7 and two levels down, executed immediately
-     * $ typo3 crawler:buildQueue 7 defaultConfiguration --depth 2 --mode exec
+     * $ typo3 crawler:buildQueue 7 default --depth 2 --mode exec
      *
      *
      * --- Put entries for re-caching pages from page 7 into queue, 4 every minute.
-     * $ typo3 crawler:buildQueue 7 defaultConfiguration --depth 0 --mode queue --number 4
+     * $ typo3 crawler:buildQueue 7 default --depth 0 --mode queue --number 4
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -131,15 +132,6 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
         $pageId = MathUtility::forceIntegerInRange($input->getArgument('page'), 0);
 
         $configurationKeys = $this->getConfigurationKeys((string) $input->getArgument('conf'));
-
-        if (! is_array($configurationKeys)) {
-            $configurations = $crawlerController->getUrlsForPageId($pageId);
-            if (is_array($configurations)) {
-                $configurationKeys = array_keys($configurations);
-            } else {
-                $configurationKeys = [];
-            }
-        }
 
         if ($mode === 'queue' || $mode === 'exec') {
             $reason = new Reason();
@@ -173,24 +165,33 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
         if ($mode === 'url') {
             $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->downloadUrls) . PHP_EOL . '</info>');
         } elseif ($mode === 'exec') {
+            $progressBar = new ProgressBar($output);
             $output->writeln('<info>Executing ' . count($crawlerController->urlList) . ' requests right away:</info>');
             $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->urlList) . '</info>' . PHP_EOL);
             $output->writeln('<info>Processing</info>' . PHP_EOL);
 
-            foreach ($crawlerController->queueEntries as $queueRec) {
+            foreach ($progressBar->iterate($crawlerController->queueEntries) as $queueRec) {
                 $p = $jsonCompatibilityConverter->convert($queueRec['parameters']);
+
+                $progressBar->clear();
                 $output->writeln('<info>' . $p['url'] . ' (' . implode(',', $p['procInstructions']) . ') => ' . '</info>' . PHP_EOL);
+                $progressBar->display();
+
                 $result = $crawlerController->readUrlFromArray($queueRec);
 
-                $resultContent = $result['content'] === null ? '' : $result['content'];
+                $resultContent = $result['content'] ?? '';
                 $requestResult = $jsonCompatibilityConverter->convert($resultContent);
+
+                $progressBar->clear();
                 if (is_array($requestResult)) {
                     $resLog = is_array($requestResult['log']) ? PHP_EOL . chr(9) . chr(9) . implode(PHP_EOL . chr(9) . chr(9), $requestResult['log']) : '';
                     $output->writeln('<info>OK: ' . $resLog . '</info>' . PHP_EOL);
                 } else {
                     $output->writeln('<error>Error checking Crawler Result:  ' . substr(preg_replace('/\s+/', ' ', strip_tags($resultContent)), 0, 30000) . '...' . PHP_EOL . '</error>' . PHP_EOL);
                 }
+                $progressBar->display();
             }
+            $output->writeln('');
         } elseif ($mode === 'queue') {
             $output->writeln('<info>Putting ' . count($crawlerController->urlList) . ' entries in queue:</info>' . PHP_EOL);
             $output->writeln('<info>' . implode(PHP_EOL, $crawlerController->urlList) . '</info>' . PHP_EOL);
@@ -204,11 +205,8 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
 
     /**
      * Obtains configuration keys from the CLI arguments
-     *
-     * @param $conf string
-     * @return array
      */
-    private function getConfigurationKeys($conf)
+    private function getConfigurationKeys(string $conf): array
     {
         $parameter = trim($conf);
         return ($parameter !== '' ? GeneralUtility::trimExplode(',', $parameter) : []);

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -104,11 +104,11 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
      * Examples:
      *
      * --- Re-cache pages from page 7 and two levels down, executed immediately
-     * $ typo3 crawler:buildQueue 7 default --depth 2 --mode exec
+     * $ typo3 crawler:buildQueue 7 defaultConfiguration --depth 2 --mode exec
      *
      *
      * --- Put entries for re-caching pages from page 7 into queue, 4 every minute.
-     * $ typo3 crawler:buildQueue 7 default --depth 0 --mode queue --number 4
+     * $ typo3 crawler:buildQueue 7 defaultConfiguration --depth 0 --mode queue --number 4
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -1230,7 +1230,7 @@ class CrawlerController implements LoggerAwareInterface
      *
      * @param array $field_array Queue field array,
      *
-     * @return string
+     * @return array|bool|mixed|string
      */
     public function readUrlFromArray($field_array)
     {

--- a/Tests/Functional/Command/BuildQueueCommandTest.php
+++ b/Tests/Functional/Command/BuildQueueCommandTest.php
@@ -55,9 +55,9 @@ class BuildQueueCommandTest extends AbstractCommandTests
      */
     public function buildQueueCommandTest(array $parameters, string $expectedOutput, int $expectedCount): void
     {
-        $commandOutput = '';
+        $commandOutput = [];
         $cliCommand = $this->getTypo3TestBinaryCommand() . ' crawler:buildQueue ' . implode(' ', $parameters);
-        CommandUtility::exec($cliCommand, $commandOutput);
+        CommandUtility::exec($cliCommand . ' 2>&1', $commandOutput);
 
         self::assertContains($expectedOutput, $commandOutput);
         self::assertEquals(

--- a/Tests/Functional/Command/BuildQueueCommandTest.php
+++ b/Tests/Functional/Command/BuildQueueCommandTest.php
@@ -55,7 +55,7 @@ class BuildQueueCommandTest extends AbstractCommandTests
      */
     public function buildQueueCommandTest(array $parameters, string $expectedOutput, int $expectedCount): void
     {
-        $commandOutput = [];
+        $commandOutput = '';
         $cliCommand = $this->getTypo3TestBinaryCommand() . ' crawler:buildQueue ' . implode(' ', $parameters);
         CommandUtility::exec($cliCommand . ' 2>&1', $commandOutput);
 


### PR DESCRIPTION
## Description
Adds a simple Symfony progress bar when using the execute mode to have a visual representation of the crawling progress.

Also removed some dead code from the command since the configuration keys are always returend as array. Fixed a wrong PHPDoc return type in CrawlerController as well.

Resolves #627 partially.

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
