### PR TITLE
[BUGFIX] Add back FE-Group initiation for TYPO3 9LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 * Detailed process views is callable again
 * Makes sure the QueueRepository is always set when needed in Domain/Model/Process
+* Crawling with FE-Groups is correct initialized with both TYPO3 9 & 10
 
 ## Crawler 9.1.1
 Crawler 9.1.1 was released on October 17th, 2020

--- a/Classes/Middleware/FrontendUserAuthenticator.php
+++ b/Classes/Middleware/FrontendUserAuthenticator.php
@@ -27,7 +27,6 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\UserAspect;
-use TYPO3\CMS\Core\Utility\DebugUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -114,11 +113,9 @@ class FrontendUserAuthenticator implements MiddlewareInterface
     }
 
     /**
-     * @param $grList
-     * @param ServerRequestInterface $request
      * @return mixed|string|\TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication
      */
-    private function getFrontendUser($grList, ServerRequestInterface $request)
+    private function getFrontendUser(string $grList, ServerRequestInterface $request)
     {
         $currentTYPO3VersionAsInteger = VersionNumberUtility::convertVersionNumberToInteger(VersionNumberUtility::getNumericTypo3Version());
         if ($currentTYPO3VersionAsInteger < 10000000) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -206,7 +206,27 @@ parameters:
 			path: Classes/Controller/CrawlerController.php
 
 		-
+			message: "#^Offset 'paramParsed' does not exist on array\\(\\)\\|array\\(\\?'origin' \\=\\> 'pagets', \\?'paramExpanded' \\=\\> array, \\?'paramParsed' \\=\\> array\\<string, string\\>, \\?'subCfg' \\=\\> array&nonEmpty, \\?'URLs' \\=\\> array\\)\\.$#"
+			count: 1
+			path: Classes/Controller/CrawlerController.php
+
+		-
+			message: "#^Offset 'paramExpanded' does not exist on array\\(\\)\\|array\\(\\?'origin' \\=\\> 'pagets', \\?'paramExpanded' \\=\\> array, \\?'paramParsed' \\=\\> array\\<string, string\\>, \\?'subCfg' \\=\\> array&nonEmpty, \\?'URLs' \\=\\> array\\)\\.$#"
+			count: 2
+			path: Classes/Controller/CrawlerController.php
+
+		-
 			message: "#^Offset 'usergroup_cached…' does not exist on array\\|null\\.$#"
+			count: 1
+			path: Classes/Controller/CrawlerController.php
+
+		-
+			message: "#^Offset 'paramParsed' does not exist on array\\(\\)\\|array\\(\\?'origin' \\=\\> string, \\?'paramExpanded' \\=\\> array, \\?'paramParsed' \\=\\> array\\<string, string\\>, \\?'subCfg' \\=\\> array, \\?'URLs' \\=\\> array\\)\\.$#"
+			count: 1
+			path: Classes/Controller/CrawlerController.php
+
+		-
+			message: "#^Offset 'paramExpanded' does not exist on array\\(\\)\\|array\\(\\?'origin' \\=\\> string, \\?'paramExpanded' \\=\\> array, \\?'paramParsed' \\=\\> array\\<string, string\\>, \\?'subCfg' \\=\\> array, \\?'URLs' \\=\\> array\\)\\.$#"
 			count: 1
 			path: Classes/Controller/CrawlerController.php
 


### PR DESCRIPTION
## Description

Resolves #643 

After 9.1.0 a regression was introduce, so that the Frontend User wasn't correct initialized on Crawler with FE-Groups.
This PR takes care of that both TYPO3 9 LTS and 10 LTS is supported.

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
