### PR TITLE
[REFACTOR] Add QueueFilter Object to operate with Object instead of string/arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Crawler 9.1.3-dev
 
+### Added
+* QueueFilter to operate with Object instead of string/arrays
+
 ### Deprecated
 #### Classes
 

--- a/Classes/Backend/RequestForm/LogRequestForm.php
+++ b/Classes/Backend/RequestForm/LogRequestForm.php
@@ -8,6 +8,7 @@ use AOE\Crawler\Backend\Helper\ResultHandler;
 use AOE\Crawler\Backend\Helper\UrlBuilder;
 use AOE\Crawler\Converter\JsonCompatibilityConverter;
 use AOE\Crawler\Utility\MessageUtility;
+use AOE\Crawler\Value\QueueFilter;
 use AOE\Crawler\Writer\FileWriter\CsvWriter\CrawlerCsvWriter;
 use AOE\Crawler\Writer\FileWriter\CsvWriter\CsvWriterInterface;
 use Doctrine\DBAL\Query\QueryBuilder;
@@ -186,6 +187,7 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
                     $doFullFlush = false;
                 }
                 $itemsPerPage = (int) $this->infoModuleController->MOD_SETTINGS['itemsPerPage'];
+                $queueFilter = new QueueFilter($this->infoModuleController->MOD_SETTINGS['log_display']);
                 // Traverse page tree:
                 $code = '';
                 $count = 0;
@@ -193,7 +195,7 @@ final class LogRequestForm extends AbstractRequestForm implements RequestFormInt
                     // Get result:
                     $logEntriesOfPage = $this->crawlerController->getLogEntriesForPageId(
                         (int) $data['row']['uid'],
-                        $this->infoModuleController->MOD_SETTINGS['log_display'],
+                        $queueFilter,
                         $doFlush,
                         $doFullFlush,
                         $itemsPerPage

--- a/Classes/Command/FlushQueueCommand.php
+++ b/Classes/Command/FlushQueueCommand.php
@@ -20,6 +20,7 @@ namespace AOE\Crawler\Command;
  */
 
 use AOE\Crawler\Controller\CrawlerController;
+use AOE\Crawler\Value\QueueFilter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -81,22 +82,22 @@ It will remove queue entries and perform a cleanup.' . chr(10) . chr(10) .
     {
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
 
-        $mode = strtolower($input->getArgument('mode'));
+        $queueFilter = new QueueFilter($input->getArgument('mode'));
 
         /** @var CrawlerController $crawlerController */
         $crawlerController = $objectManager->get(CrawlerController::class);
 
         $pageId = MathUtility::forceIntegerInRange($input->getOption('page'), 0);
 
-        switch ($mode) {
+        switch ($queueFilter) {
             case 'all':
-                $crawlerController->getLogEntriesForPageId($pageId, '', true, true);
+                $crawlerController->getLogEntriesForPageId($pageId, $queueFilter, true, true);
                 $output->writeln('<info>All entries in Crawler queue will be flushed</info>');
                 break;
             case 'finished':
             case 'pending':
-                $crawlerController->getLogEntriesForPageId($pageId, (string) $mode, true, false);
-                $output->writeln('<info>All entries in Crawler queue, with status: "' . $mode . '" will be flushed</info>');
+                $crawlerController->getLogEntriesForPageId($pageId, $queueFilter, true, false);
+                $output->writeln('<info>All entries in Crawler queue, with status: "' . $queueFilter . '" will be flushed</info>');
                 break;
             default:
                 $output->writeln('<info>No matching parameters found.' . PHP_EOL . 'Try "typo3 help crawler:flushQueue" to see your options</info>');

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -39,6 +39,7 @@ use AOE\Crawler\Domain\Repository\QueueRepository;
 use AOE\Crawler\QueueExecutor;
 use AOE\Crawler\Service\UrlService;
 use AOE\Crawler\Utility\SignalSlotUtility;
+use AOE\Crawler\Value\QueueFilter;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -929,13 +930,13 @@ class CrawlerController implements LoggerAwareInterface
      * Return array of records from crawler queue for input page ID
      *
      * @param integer $id Page ID for which to look up log entries.
-     * @param string $filter Filter: "all" => all entries, "pending" => all that is not yet run, "finished" => all complete ones
+     * @param QueueFilter $filter Filter: "all" => all entries, "pending" => all that is not yet run, "finished" => all complete ones
      * @param boolean $doFlush If TRUE, then entries selected at DELETED(!) instead of selected!
      * @param boolean $doFullFlush
      * @param integer $itemsPerPage Limit the amount of entries per page default is 10
      * @return array
      */
-    public function getLogEntriesForPageId($id, $filter = '', $doFlush = false, $doFullFlush = false, $itemsPerPage = 10)
+    public function getLogEntriesForPageId($id, QueueFilter $queueFilter, $doFlush = false, $doFullFlush = false, $itemsPerPage = 10)
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($this->tableName);
         $queryBuilder
@@ -953,7 +954,7 @@ class CrawlerController implements LoggerAwareInterface
         // PHPStorm adds the highlight that the $addWhere is immediately overwritten,
         // but the $query = $expressionBuilder->andX() ensures that the $addWhere is written correctly with AND
         // between the statements, it's not a mistake in the code.
-        switch ($filter) {
+        switch ($queueFilter) {
             case 'pending':
                 $queryBuilder->andWhere($queryBuilder->expr()->eq('exec_time', 0));
                 break;
@@ -964,9 +965,9 @@ class CrawlerController implements LoggerAwareInterface
 
         if ($doFlush) {
             if ($doFullFlush) {
-                $this->queueRepository->flushQueue('all');
+                $this->queueRepository->flushQueue($queueFilter);
             } else {
-                $this->queueRepository->flushQueue($filter);
+                $this->queueRepository->flushQueue($queueFilter);
             }
         }
         if ($itemsPerPage > 0) {

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -930,7 +930,6 @@ class CrawlerController implements LoggerAwareInterface
      * Return array of records from crawler queue for input page ID
      *
      * @param integer $id Page ID for which to look up log entries.
-     * @param QueueFilter $filter Filter: "all" => all entries, "pending" => all that is not yet run, "finished" => all complete ones
      * @param boolean $doFlush If TRUE, then entries selected at DELETED(!) instead of selected!
      * @param boolean $doFullFlush
      * @param integer $itemsPerPage Limit the amount of entries per page default is 10

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -30,6 +30,7 @@ namespace AOE\Crawler\Domain\Repository;
 
 use AOE\Crawler\Configuration\ExtensionConfigurationProvider;
 use AOE\Crawler\Domain\Model\Process;
+use AOE\Crawler\Value\QueueFilter;
 use Psr\Log\LoggerAwareInterface;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -590,11 +591,11 @@ class QueueRepository extends Repository implements LoggerAwareInterface
      *
      * @param string $filter all, pending, finished
      */
-    public function flushQueue(string $filter): void
+    public function flushQueue(QueueFilter $queueFilter): void
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($this->tableName);
 
-        switch (strtolower($filter)) {
+        switch ($queueFilter) {
             case 'all':
                 // No where claus needed delete everything
                 break;

--- a/Classes/Domain/Repository/QueueRepository.php
+++ b/Classes/Domain/Repository/QueueRepository.php
@@ -588,8 +588,6 @@ class QueueRepository extends Repository implements LoggerAwareInterface
 
     /**
      * Removes queue entries
-     *
-     * @param string $filter all, pending, finished
      */
     public function flushQueue(QueueFilter $queueFilter): void
     {

--- a/Classes/Value/QueueFilter.php
+++ b/Classes/Value/QueueFilter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AOE\Crawler\Value;
+
+/*
+ * (c) 2020 AOE GmbH <dev@aoe.com>
+ *
+ * This file is part of the TYPO3 Crawler Extension.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Assert\Assert;
+
+class QueueFilter
+{
+    /**
+     * @var string
+     */
+    private $queueFilter;
+
+    public function __construct(string $queueFilter = 'all')
+    {
+        Assert::that($queueFilter)
+            ->inArray(['all', 'pending', 'finished']);
+
+        $this->queueFilter = $queueFilter;
+    }
+
+    public function __toString()
+    {
+        return $this->queueFilter;
+    }
+}

--- a/Tests/Functional/Command/FlushQueueCommandTest.php
+++ b/Tests/Functional/Command/FlushQueueCommandTest.php
@@ -86,11 +86,6 @@ class FlushQueueCommandTest extends AbstractCommandTests
                 'expectedOutput' => 'All entries in Crawler queue, with status: "finished" will be flushed',
                 'expectedCount' => 8,
             ],
-            'Unknown mode' => [
-                'mode' => 'unknown',
-                'expectedOutput' => 'No matching parameters found.',
-                'expectedCount' => 15,
-            ],
         ];
     }
 }

--- a/Tests/Functional/Controller/CrawlerControllerTest.php
+++ b/Tests/Functional/Controller/CrawlerControllerTest.php
@@ -30,6 +30,7 @@ namespace AOE\Crawler\Tests\Functional\Controller;
 
 use AOE\Crawler\Controller\CrawlerController;
 use AOE\Crawler\Domain\Repository\QueueRepository;
+use AOE\Crawler\Value\QueueFilter;
 use Nimut\TestingFramework\MockObject\AccessibleMockObjectInterface;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -118,11 +119,11 @@ class CrawlerControllerTest extends FunctionalTestCase
      *
      * @dataProvider getLogEntriesForPageIdDataProvider
      */
-    public function getLogEntriesForPageId(int $id, string $filter, bool $doFlush, bool $doFullFlush, int $itemsPerPage, array $expected): void
+    public function getLogEntriesForPageId(int $id, QueueFilter $queueFilter, bool $doFlush, bool $doFullFlush, int $itemsPerPage, array $expected): void
     {
         self::assertEquals(
             $expected,
-            $this->subject->getLogEntriesForPageId($id, $filter, $doFlush, $doFullFlush, $itemsPerPage)
+            $this->subject->getLogEntriesForPageId($id, $queueFilter, $doFlush, $doFullFlush, $itemsPerPage)
         );
     }
 
@@ -528,7 +529,7 @@ class CrawlerControllerTest extends FunctionalTestCase
         return [
             'Do Flush' => [
                 'id' => 1002,
-                'filter' => '',
+                'filter' => new QueueFilter(),
                 'doFlush' => true,
                 'doFullFlush' => false,
                 'itemsPerPage' => 5,
@@ -536,7 +537,7 @@ class CrawlerControllerTest extends FunctionalTestCase
             ],
             'Do Full Flush' => [
                 'id' => 1002,
-                'filter' => '',
+                'filter' => new QueueFilter(),
                 'doFlush' => true,
                 'doFullFlush' => true,
                 'itemsPerPage' => 5,
@@ -544,7 +545,7 @@ class CrawlerControllerTest extends FunctionalTestCase
             ],
             'Check that doFullFlush do not flush if doFlush is not true' => [
                 'id' => 2,
-                'filter' => '',
+                'filter' => new QueueFilter(),
                 'doFlush' => false,
                 'doFullFlush' => true,
                 'itemsPerPage' => 5,
@@ -566,7 +567,7 @@ class CrawlerControllerTest extends FunctionalTestCase
             ],
             'Get entries for page_id 2001' => [
                 'id' => 2,
-                'filter' => '',
+                'filter' => new QueueFilter(),
                 'doFlush' => false,
                 'doFullFlush' => false,
                 'itemsPerPage' => 1,

--- a/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
@@ -21,6 +21,7 @@ namespace AOE\Crawler\Tests\Functional\Domain\Repository;
 
 use AOE\Crawler\Domain\Model\Process;
 use AOE\Crawler\Domain\Repository\QueueRepository;
+use AOE\Crawler\Value\QueueFilter;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -554,11 +555,11 @@ class QueueRepositoryTest extends FunctionalTestCase
      *
      * @dataProvider flushQueueDataProvider
      */
-    public function flushQueue(string $where, int $expected): void
+    public function flushQueue(QueueFilter $queueFilter, int $expected): void
     {
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
         $queryRepository = $objectManager->get(QueueRepository::class);
-        $this->subject->flushQueue($where);
+        $this->subject->flushQueue($queueFilter);
 
         self::assertSame(
             $expected,
@@ -570,19 +571,15 @@ class QueueRepositoryTest extends FunctionalTestCase
     {
         return [
             'Flush Entire Queue' => [
-                'filter' => 'all',
+                'filter' => new QueueFilter('all'),
                 'expected' => 0,
             ],
             'Flush Pending entries' => [
-                'filter' => 'pending',
+                'filter' => new QueueFilter('pending'),
                 'expected' => 7,
             ],
             'Flush Finished entries' => [
-                'filter' => 'finished',
-                'expected' => 8,
-            ],
-            'Other parameter given, default to finished' => [
-                'filter' => 'not-existing-param',
+                'filter' => new QueueFilter('finished'),
                 'expected' => 8,
             ],
         ];

--- a/Tests/Unit/Value/QueueFilterTest.php
+++ b/Tests/Unit/Value/QueueFilterTest.php
@@ -19,22 +19,33 @@ namespace AOE\Crawler\Tests\Unit\Value;
  * The TYPO3 project - inspiring people to share!
  */
 
-use AOE\Crawler\Value\CrawlAction;
+use AOE\Crawler\Value\QueueFilter;
 use Nimut\TestingFramework\TestCase\UnitTestCase;
 
-class CrawlActionTest extends UnitTestCase
+class QueueFilterTest extends UnitTestCase
 {
-    public const VALID_VALUE = 'start';
+    public const VALID_VALUE = 'finished';
+
+    /**
+     * @test
+     */
+    public function defaultValueConstructor(): void
+    {
+        self::assertEquals(
+            'all',
+            new QueueFilter()
+        );
+    }
 
     /**
      * @test
      */
     public function toStringWithValidValueReturnsOriginalValue(): void
     {
-        $crawlAction = new CrawlAction(self::VALID_VALUE);
+        $queueFilter = new QueueFilter(self::VALID_VALUE);
         self::assertEquals(
             self::VALID_VALUE,
-            $crawlAction->__toString()
+            $queueFilter->__toString()
         );
     }
 
@@ -44,6 +55,7 @@ class CrawlActionTest extends UnitTestCase
     public function constructorThrowsException(): void
     {
         self::expectException(\InvalidArgumentException::class);
-        new CrawlAction('INVALID');
+        new QueueFilter('INVALID');
     }
+
 }

--- a/Tests/Unit/Value/QueueFilterTest.php
+++ b/Tests/Unit/Value/QueueFilterTest.php
@@ -57,5 +57,4 @@ class QueueFilterTest extends UnitTestCase
         self::expectException(\InvalidArgumentException::class);
         new QueueFilter('INVALID');
     }
-
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -221,7 +221,7 @@ parameters:
 			path: Classes/Command/BuildQueueCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function strtolower expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$queueFilter of class AOE\\\\Crawler\\\\Value\\\\QueueFilter constructor expects string, array\\<string\\>\\|string\\|null given\\.$#"
 			count: 1
 			path: Classes/Command/FlushQueueCommand.php
 


### PR DESCRIPTION
## Description

This PR adds a QeueuFilter ValueObject to work with Objects instead of strings and arrays when handling the QueueFilters, on FlushQueue etc.

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
