### PR TITLE
[REFACTOR] Move GetDuplicateRowIfExists to the QueueRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * IndexedSearchCrawlerHook
 
 #### Functions & Properties
-
+* CrawlerController->getDuplicateRowsIfExist()
 
 ### Removed
 #### Classes

--- a/Classes/Command/ProcessQueueCommand.php
+++ b/Classes/Command/ProcessQueueCommand.php
@@ -36,7 +36,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -209,6 +209,7 @@ class CrawlerController implements LoggerAwareInterface
         'setDisabled' => 'Using CrawlerController->setDisabled() is deprecated since 9.1.3 and will be removed in v11.x, please use Crawler->setDisabled() instead',
         'getProcessFilename' => 'Using CrawlerController->getProcessFilename() is deprecated since 9.1.3 and will be removed in v11.x',
         'setProcessFilename' => 'Using CrawlerController->setProcessFilename() is deprecated since 9.1.3 and will be removed in v11.x',
+        'getDuplicateRowsIfExist' => 'Using CrawlerController->getDuplicateRowsIfExist() is deprecated since 9.1.4 and will be remove in v11.x, please use QueueRepository->getDuplicateQueueItemsIfExists() instead',
 
     ];
 
@@ -1125,7 +1126,13 @@ class CrawlerController implements LoggerAwareInterface
         } else {
             if (! $skipInnerDuplicationCheck) {
                 // check if there is already an equal entry
-                $rows = $this->getDuplicateRowsIfExist($tstamp, $fieldArray);
+                $rows = $this->queueRepository->getDuplicateQueueItemsIfExists(
+                    (bool) $this->extensionSettings['enableTimeslot'],
+                    $tstamp,
+                    $this->getCurrentTime(),
+                    $fieldArray['page_id'],
+                    $fieldArray['parameters_hash']
+                );
             }
 
             if (empty($rows)) {
@@ -1868,6 +1875,7 @@ class CrawlerController implements LoggerAwareInterface
      * @param array $fieldArray
      *
      * @return array
+     * @deprecated
      */
     protected function getDuplicateRowsIfExist($tstamp, $fieldArray)
     {

--- a/Tests/Functional/Controller/CrawlerControllerTest.php
+++ b/Tests/Functional/Controller/CrawlerControllerTest.php
@@ -220,16 +220,13 @@ class CrawlerControllerTest extends FunctionalTestCase
      */
     public function addUrl(int $id, string $url, array $subCfg, int $tstamp, string $configurationHash, bool $skipInnerDuplicationCheck, array $mockedDuplicateRowResult, bool $registerQueueEntriesInternallyOnly, bool $expected): void
     {
-        $mockedCrawlerController = $this->getAccessibleMock(CrawlerController::class, ['getDuplicateRowsIfExist']);
-        $mockedCrawlerController->expects($this->any())->method('getDuplicateRowsIfExist')->withAnyParameters()->willReturn($mockedDuplicateRowResult);
+        $mockedQueueRepository = $this->getAccessibleMock(QueueRepository::class, ['getDuplicateQueueItemsIfExists']);
+        $mockedQueueRepository->expects($this->any())->method('getDuplicateQueueItemsIfExists')->willReturn($mockedDuplicateRowResult);
+
+        $mockedCrawlerController = $this->getAccessibleMock(CrawlerController::class, ['dummy']);
 
         $mockedCrawlerController->_set('registerQueueEntriesInternallyOnly', $registerQueueEntriesInternallyOnly);
-
-        // Checking the mock of getDuplicateRowsIfExist()
-        self::assertEquals(
-            $mockedDuplicateRowResult,
-            $mockedCrawlerController->_call('getDuplicateRowsIfExist', 1234, [])
-        );
+        $mockedCrawlerController->_set('queueRepository', $mockedQueueRepository);
 
         self::assertEquals(
             $expected,

--- a/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
@@ -642,7 +642,7 @@ class QueueRepositoryTest extends FunctionalTestCase
             ],
         ];
     }
-    
+
     /**
      * @return array
      */

--- a/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/QueueRepositoryTest.php
@@ -586,6 +586,64 @@ class QueueRepositoryTest extends FunctionalTestCase
     }
 
     /**
+     * @test
+     * @dataProvider getDuplicateQueueItemsIfExistsDataProvider
+     */
+    public function getDuplicateQueueItemsIfExists(bool $enableTimeslot, int $timestamp, int $currentTime, int $pageId, string $parametersHash, array $expected): void
+    {
+        self::assertSame(
+            $expected,
+            $this->subject->getDuplicateQueueItemsIfExists($enableTimeslot, $timestamp, $currentTime, $pageId, $parametersHash)
+        );
+    }
+
+    public function getDuplicateQueueItemsIfExistsDataProvider(): array
+    {
+        return [
+            'EnableTimeslot is true and timestamp is <= current' => [
+                'timeslotActive' => true,
+                'tstamp' => 10,
+                'current' => 12,
+                'page_id' => 10,
+                'parameters_hash' => '',
+                'expected' => [18, 20],
+            ],
+            'EnableTimeslot is false and timestamp is <= current' => [
+                'timeslotActive' => false,
+                'tstamp' => 11,
+                'current' => 11,
+                'page_id' => 10,
+                'parameters_hash' => '',
+                'expected' => [18],
+            ],
+            'EnableTimeslot is true and timestamp is > current' => [
+                'timeslotActive' => true,
+                'tstamp' => 12,
+                'current' => 10,
+                'page_id' => 10,
+                'parameters_hash' => '',
+                'expected' => [20],
+            ],
+            'EnableTimeslot is false and timestamp is > current' => [
+                'timeslotActive' => false,
+                'tstamp' => 12,
+                'current' => 10,
+                'page_id' => 10,
+                'parameters_hash' => '',
+                'expected' => [20],
+            ],
+            'EnableTimeslot is false and timestamp is > current and parameters_hash is set' => [
+                'timeslotActive' => false,
+                'tstamp' => 12,
+                'current' => 10,
+                'page_id' => 10,
+                'parameters_hash' => 'NotReallyAHashButWillDoForTesting',
+                'expected' => [19],
+            ],
+        ];
+    }
+    
+    /**
      * @return array
      */
     public function isPageInQueueDataProvider()

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -572,7 +572,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method fetch\\(\\) on Doctrine\\\\DBAL\\\\Driver\\\\Statement\\|int\\.$#"
-			count: 8
+			count: 9
 			path: Classes/Domain/Repository/QueueRepository.php
 
 		-
@@ -877,11 +877,11 @@ parameters:
 
 		-
 			message: "#^Method Nimut\\\\TestingFramework\\\\MockObject\\\\AccessibleMockObjectInterface\\:\\:_call\\(\\) invoked with 3 parameters, 1 required\\.$#"
-			count: 2
+			count: 1
 			path: Tests/Functional/Controller/CrawlerControllerTest.php
 
 		-
-			message: "#^Trying to mock an undefined method getDuplicateRowsIfExist\\(\\) on class Nimut\\\\TestingFramework\\\\MockObject\\\\AccessibleMockObjectInterface\\.$#"
+			message: "#^Trying to mock an undefined method getDuplicateQueueItemsIfExists\\(\\) on class Nimut\\\\TestingFramework\\\\MockObject\\\\AccessibleMockObjectInterface\\.$#"
 			count: 1
 			path: Tests/Functional/Controller/CrawlerControllerTest.php
 


### PR DESCRIPTION
## Description

This moves the GetDuplicateRowIfExists to the QueueRepository where it belongs. 
The one in CrawlerController is marked as deprecated. 

Resolves #376 

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
