### PR TITLE
[BUGFIX] Assign port as string to $_SERVER['port'] in cli/bootstrap.php

### DIFF
--- a/cli/bootstrap.php
+++ b/cli/bootstrap.php
@@ -70,7 +70,7 @@ $_SERVER['REQUEST_METHOD'] = 'GET';
     // Define a port if used in the URL:
 if (isset($urlParts['port'])) {
     $_SERVER['HTTP_HOST'] .= ':' . $urlParts['port'];
-    $_SERVER['SERVER_PORT'] = $urlParts['port'];
+    $_SERVER['SERVER_PORT'] = (string)$urlParts['port'];
 }
 
     // Define HTTPS disposal:


### PR DESCRIPTION
## Description

Resolves #662: Bug in cli command 'crawler:processQueue' related to 'trustedHostsPattern'
