### PR TITLE
[TASK] Add error handling when page 0 is used for buildQueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Crawler 9.1.5-dev
 
+### Added
+* Error when Page 0 is used for crawler:buildQueue
+
+
 ### Change
 * Removed all references to cHash as it is not used anymore.
 

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -132,9 +132,9 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
 
         $pageId = MathUtility::forceIntegerInRange($input->getArgument('page'), 0);
         if ($pageId === 0) {
-            $message = "Page $pageId is not a valid page, please check you root page id and try again.";
+            $message = "Page ${pageId} is not a valid page, please check you root page id and try again.";
             MessageUtility::addErrorMessage($message);
-            $output->writeln("<info>$message</info>");
+            $output->writeln("<info>${message}</info>");
             return 1;
         }
 

--- a/Classes/Command/BuildQueueCommand.php
+++ b/Classes/Command/BuildQueueCommand.php
@@ -24,6 +24,7 @@ use AOE\Crawler\Controller\CrawlerController;
 use AOE\Crawler\Converter\JsonCompatibilityConverter;
 use AOE\Crawler\Domain\Model\Reason;
 use AOE\Crawler\Domain\Repository\QueueRepository;
+use AOE\Crawler\Utility\MessageUtility;
 use AOE\Crawler\Utility\SignalSlotUtility;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -130,6 +131,12 @@ re-indexing or static publishing from command line.' . chr(10) . chr(10) .
         }
 
         $pageId = MathUtility::forceIntegerInRange($input->getArgument('page'), 0);
+        if ($pageId === 0) {
+            $message = "Page $pageId is not a valid page, please check you root page id and try again.";
+            MessageUtility::addErrorMessage($message);
+            $output->writeln("<info>$message</info>");
+            return 1;
+        }
 
         $configurationKeys = $this->getConfigurationKeys((string) $input->getArgument('conf'));
 

--- a/Tests/Functional/Command/BuildQueueCommandTest.php
+++ b/Tests/Functional/Command/BuildQueueCommandTest.php
@@ -97,6 +97,11 @@ class BuildQueueCommandTest extends AbstractCommandTests
                 'expectedOutput' => 'Executing 1 requests right away:',
                 'expectedCount' => 1,
             ],
+            'Start page 0, expecting error' => [
+                'parameters' => [0, $crawlerConfiguration, '--mode queue'],
+                'expectedOutput' => 'Page 0 is not a valid page, please check you root page id and try again.',
+                'expectedCount' => 0,
+            ],
         ];
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -208,7 +208,7 @@ parameters:
 			path: Classes/Backend/RequestForm/StartRequestForm.php
 
 		-
-			message: "#^Cognitive complexity for \"AOE\\\\Crawler\\\\Command\\\\BuildQueueCommand\\:\\:execute\\(\\)\" is 18, keep it under 8$#"
+			message: "#^Cognitive complexity for \"AOE\\\\Crawler\\\\Command\\\\BuildQueueCommand\\:\\:execute\\(\\)\" is 19, keep it under 8$#"
 			count: 1
 			path: Classes/Command/BuildQueueCommand.php
 


### PR DESCRIPTION
## Description

Adds Error information when page 0 is used for crawler:buildQueue

Resolves: #649 

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [x] Added tests for the new code
