### PR TITLE
[FIX] Added extension key into composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
         },
         "typo3/cms": {
             "cms-package-dir": "{$vendor-dir}/typo3/cms",
+            "extension-key": "crawler",
             "web-dir": ".Build/Web"
         }
     },


### PR DESCRIPTION
## Description

<!-- What does this PR do -->
This PR adds the extension key inside composer.json

<!-- Does this solve an existing issue, then please reference with #issue-number -->
Providing the extension key inside composer.json is mandatory in future TYPO3 versions

**I have**

- [x] Checked that CGL are followed
- [ ] Checked that the Tests are still working
- [ ] Added description to CHANGELOG.md (github-handle is optional)
- [ ] Added tests for the new code
