### PR TITLE
[CLEANUP] Remove auto-created fields in ext_tables.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog TYPO3 Crawler
 
+## Crawler 9.2.3-dev
+
+###Added
+
+###Changed
+* Default fields in `tx_crawler_configuration` are remove from `ext_table.sql` as they are obsolete, will be added from TCA
+
+###Deprecated
+#### Functions & Properties
+
+###Removed
+#### Functions & Properties
+
+###Fixed
+
+###Security
+
 ## Crawler 9.2.2
 Crawler 9.2.2 was released on January 26th, 2021
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -46,13 +46,6 @@ CREATE TABLE tx_crawler_process (
 # Table structure for table 'tx_crawler_configuration'
 #
 CREATE TABLE tx_crawler_configuration (
-  uid int(11) NOT NULL auto_increment,
-  pid int(11) DEFAULT '0' NOT NULL,
-  tstamp int(11) DEFAULT '0' NOT NULL,
-  crdate int(11) DEFAULT '0' NOT NULL,
-  cruser_id int(11) DEFAULT '0' NOT NULL,
-  deleted tinyint(4) DEFAULT '0' NOT NULL,
-  hidden tinyint(4) DEFAULT '0' NOT NULL,
   name tinytext NOT NULL,
   force_ssl tinyint(4) DEFAULT '0' NOT NULL,
   processing_instruction_filter varchar(200) DEFAULT '' NOT NULL,
@@ -62,10 +55,8 @@ CREATE TABLE tx_crawler_configuration (
   pidsonly blob,
   begroups varchar(100) DEFAULT '0' NOT NULL,
   fegroups varchar(100) DEFAULT '0' NOT NULL,
-  exclude text NOT NULL,
+  exclude text NOT NULL
 
-  PRIMARY KEY (uid),
-  KEY parent (pid)
 ) ENGINE=InnoDB;
 
 #


### PR DESCRIPTION
Default fields in `tx_crawler_configuration` are remove from
`ext_table.sql` as they are obsolete, will be added from TCA

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.3/Feature-85160-AutoCreateManagementDBFieldsFromTCACtrl.html

Resolves #710 