### PR TITLE
[CI] Use path package of extension for acceptance tests

### DIFF
--- a/.devbox/composer.json
+++ b/.devbox/composer.json
@@ -23,11 +23,15 @@
         "typo3/cms-belog": "^9.5 || ^10.4",
         "bk2k/bootstrap-package": "^10.0 || ^11.0",
         "helhum/typo3-console": "*",
-        "aoepeople/crawler": "dev-main",
+        "aoepeople/crawler": "*@dev",
         "typo3/cms-beuser": "^9.5 || ^10.4",
         "georgringer/news": "*"
     },
     "repositories": [
+        {
+            "type": "path",
+            "url": "../"
+        },
         {
             "type": "git",
             "url": "https://github.com/tomasnorre/bootstrap_package.git"

--- a/.github/workflows/Acceptance.yml
+++ b/.github/workflows/Acceptance.yml
@@ -43,7 +43,7 @@ jobs:
       - run: |
           cd .devbox
           rm -rf vendor composer.lock
-          ddev composer require aoepeople/crawler:dev-${{ env.BRANCH_NAME }} nimut/typo3-complete=${{ matrix.typo3 }}
+          ddev composer require nimut/typo3-complete=${{ matrix.typo3 }}
           ddev start
           ddev exec bin/typo3cms install:fixfolderstructure
           ddev exec bin/typo3cms install:extensionsetupifpossible


### PR DESCRIPTION
## Description

Instead of requiring the changes via composer (which seems not to work for PRs) from the
dedicated branch use the already checked out sources.

The extension sources are then symlinked to .devbox/typo3conf/ext/crawler.