### PR TITLE
Explain _RECURSIVE flag in documentation

### DIFF
--- a/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
+++ b/Documentation/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.rst
@@ -49,6 +49,9 @@ Page TSconfig Reference (tx\_crawler.crawlerCfg)
              - Keyword " **\_PID** ": Value is optional page id to look in (default
                is current page).
 
+             - Keyword " **\_RECURSIVE** ": Optional flag to set recursive crawl
+               depth. Default is 0.
+
              - Keyword " **\_FIELD** ": Value is field name to use for the value
                (default is uid).
 


### PR DESCRIPTION
Hi there, I recently searched for an option to crawl multiple news folders at once. Within the code I found the _RECURSIVE flag which is not explained in the documentation yet (https://docs.typo3.org/p/aoepeople/crawler/9.2/en-us/Configuration/PageTsconfigReference(txCrawlercrawlercfg)/Index.html).