### PR TITLE
[REFACTOR] Add cli methods to ProcessCommand and deprecated them in CrawlerController

### DIFF
--- a/.github/workflows/MutationTests.yml
+++ b/.github/workflows/MutationTests.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: "Infection"
         # --min-msi and --min-covered-msi can be moved to infection.json.dist when upgrading to ^0.16
-        run: ".Build/bin/infection --min-msi=16 --min-covered-msi=94 --threads=8"
+        run: "composer test:mutation"
         env:
           #INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@
 #### Classes
 #### Functions & Properties
 * CrawlerController->checkIfPageShouldBeSkipped()
+* CrawlerController->CLI_buildProcessId()
+* CrawlerController->CLI_checkAndAcquireNewProcess()
+* CrawlerController->CLI_run()
 
 ### Removed
 #### Classes

--- a/Classes/Command/ProcessQueueCommand.php
+++ b/Classes/Command/ProcessQueueCommand.php
@@ -326,18 +326,17 @@ class ProcessQueueCommand extends Command
 
     private function getCrawlerController(): CrawlerController
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        return $this->crawlerController ?? $objectManager->get(CrawlerController::class);
+        return $this->crawlerController ?? GeneralUtility::makeInstance(CrawlerController::class);
     }
 
     private function getProcessRepository(): ProcessRepository
     {
-        return $this->processRepository ?? new ProcessRepository();
+        return $this->processRepository ?? GeneralUtility::makeInstance(ProcessRepository::class);
     }
 
     private function getQueueRepository(): QueueRepository
     {
-        return $this->queueRepository ?? new QueueRepository();
+        return $this->queueRepository ?? GeneralUtility::makeInstance(QueueRepository::class);
     }
 
     private function getExtensionSettings(): array

--- a/Classes/Command/ProcessQueueCommand.php
+++ b/Classes/Command/ProcessQueueCommand.php
@@ -28,8 +28,10 @@ namespace AOE\Crawler\Command;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use AOE\Crawler\Configuration\ExtensionConfigurationProvider;
 use AOE\Crawler\Controller\CrawlerController;
 use AOE\Crawler\Crawler;
+use AOE\Crawler\Domain\Model\Process;
 use AOE\Crawler\Domain\Repository\ProcessRepository;
 use AOE\Crawler\Domain\Repository\QueueRepository;
 use Symfony\Component\Console\Command\Command;
@@ -41,18 +43,63 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class ProcessQueueCommand extends Command
 {
+    /**
+     * @deprecated since 9.2.5 will be made private in v11.x
+     */
     public const CLI_STATUS_NOTHING_PROCCESSED = 0;
 
-    //queue not empty
+    /**
+     * queue not empty
+     * @deprecated since 9.2.5 will be made private in v11.x
+     */
     public const CLI_STATUS_REMAIN = 1;
 
-    //(some) queue items where processed
+    /**
+     * (some) queue items where processed
+     * @deprecated since 9.2.5 will be made private in v11.x
+     */
     public const CLI_STATUS_PROCESSED = 2;
 
-    //instance didn't finish
+    /**
+     * instance didn't finish
+     * @deprecated since 9.2.5 will be made private in v11.x
+     */
     public const CLI_STATUS_ABORTED = 4;
 
+    /**
+     * @deprecated since 9.2.5 will be made private in v11.x
+     */
     public const CLI_STATUS_POLLABLE_PROCESSED = 8;
+
+    /**
+     * @var Crawler
+     */
+    private $crawler;
+
+    /**
+     * @var CrawlerController
+     */
+    private $crawlerController;
+
+    /**
+     * @var ProcessRepository
+     */
+    private $processRepository;
+
+    /**
+     * @var QueueRepository
+     */
+    private $queueRepository;
+
+    /**
+     * @var string
+     */
+    private $processId;
+
+    /**
+     * @var array
+     */
+    private $extensionSettings;
 
     /**
      * Crawler Command - Crawling the URLs from the queue
@@ -71,11 +118,10 @@ class ProcessQueueCommand extends Command
         $sleepafter = $input->getOption('sleepafter');
 
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+        $this->extensionSettings = $this->getExtensionSettings();
 
         $result = self::CLI_STATUS_NOTHING_PROCCESSED;
 
-        /** @var CrawlerController $crawlerController */
-        $crawlerController = $objectManager->get(CrawlerController::class);
         /** @var QueueRepository $queueRepository */
         $queueRepository = $objectManager->get(QueueRepository::class);
         /** @var ProcessRepository $processRepository */
@@ -84,14 +130,14 @@ class ProcessQueueCommand extends Command
         /** @var Crawler $crawler */
         $crawler = GeneralUtility::makeInstance(Crawler::class);
 
-        if (! $crawler->isDisabled() && $crawlerController->CLI_checkAndAcquireNewProcess($crawlerController->CLI_buildProcessId())) {
-            $countInARun = $amount ? (int) $amount : (int) $crawlerController->extensionSettings['countInARun'];
-            $sleepAfterFinish = $sleepafter ? (int) $sleepafter : (int) $crawlerController->extensionSettings['sleepAfterFinish'];
-            $sleepTime = $sleeptime ? (int) $sleeptime : (int) $crawlerController->extensionSettings['sleepTime'];
+        if (! $crawler->isDisabled() && $this->checkAndAcquireNewProcess($this->getProcessId())) {
+            $countInARun = $amount ? (int) $amount : (int) $this->extensionSettings['countInARun'];
+            $sleepAfterFinish = $sleepafter ? (int) $sleepafter : (int) $this->extensionSettings['sleepAfterFinish'];
+            $sleepTime = $sleeptime ? (int) $sleeptime : (int) $this->extensionSettings['sleepTime'];
 
             try {
                 // Run process:
-                $result = $crawlerController->CLI_run($countInARun, $sleepTime, $sleepAfterFinish);
+                $result = $this->runProcess($countInARun, $sleepTime, $sleepAfterFinish);
             } catch (\Throwable $e) {
                 $output->writeln('<warning>' . get_class($e) . ': ' . $e->getMessage() . '</warning>');
                 $result = self::CLI_STATUS_ABORTED;
@@ -99,10 +145,10 @@ class ProcessQueueCommand extends Command
 
             // Cleanup
             $processRepository->deleteProcessesWithoutItemsAssigned();
-            $processRepository->markRequestedProcessesAsNotActive([$crawlerController->CLI_buildProcessId()]);
-            $queueRepository->unsetProcessScheduledAndProcessIdForQueueEntries([$crawlerController->CLI_buildProcessId()]);
+            $processRepository->markRequestedProcessesAsNotActive([$this->getProcessId()]);
+            $queueRepository->unsetProcessScheduledAndProcessIdForQueueEntries([$this->getProcessId()]);
 
-            $output->writeln('<info>Unprocessed Items remaining:' . count($queueRepository->getUnprocessedItems()) . ' (' . $crawlerController->CLI_buildProcessId() . ')</info>');
+            $output->writeln('<info>Unprocessed Items remaining:' . count($queueRepository->getUnprocessedItems()) . ' (' . $this->getProcessId() . ')</info>');
             $result |= (count($queueRepository->getUnprocessedItems()) > 0 ? self::CLI_STATUS_REMAIN : self::CLI_STATUS_NOTHING_PROCCESSED);
         } else {
             $result |= self::CLI_STATUS_ABORTED;
@@ -146,5 +192,156 @@ class ProcessQueueCommand extends Command
             InputOption::VALUE_OPTIONAL,
             'Amount of seconds which the system should use to relax after all crawls are done.'
         );
+    }
+
+    /**
+     * Running the functionality of the CLI (crawling URLs from queue)
+     */
+    private function runProcess(int $countInARun, int $sleepTime, int $sleepAfterFinish): int
+    {
+        $result = 0;
+        $counter = 0;
+
+        // First, run hooks:
+        foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['crawler']['cli_hooks'] ?? [] as $objRef) {
+            trigger_error(
+                'This hook (crawler/cli_hooks) is deprecated since 9.1.5 and will be removed when dropping support for TYPO3 9LTS and 10LTS',
+                E_USER_DEPRECATED
+            );
+            $hookObj = GeneralUtility::makeInstance($objRef);
+            if (is_object($hookObj)) {
+                $hookObj->crawler_init($this->getCrawlerController());
+            }
+        }
+
+        // Clean up the queue
+        $this->getQueueRepository()->cleanupQueue();
+
+        // Select entries:
+        $records = $this->getQueueRepository()->fetchRecordsToBeCrawled($countInARun);
+
+        if (! empty($records)) {
+            $quidList = [];
+
+            foreach ($records as $record) {
+                $quidList[] = $record['qid'];
+            }
+
+            $processId = $this->getProcessId();
+
+            //save the number of assigned queue entries to determine how many have been processed later
+            $numberOfAffectedRows = $this->getQueueRepository()->updateProcessIdAndSchedulerForQueueIds($quidList, $processId);
+            $this->getProcessRepository()->updateProcessAssignItemsCount($numberOfAffectedRows, $processId);
+
+            if ($numberOfAffectedRows !== count($quidList)) {
+                return ($result | self::CLI_STATUS_ABORTED);
+            }
+
+            foreach ($records as $record) {
+                $result |= $this->getCrawlerController()->readUrl($record['qid']);
+
+                $counter++;
+                // Just to relax the system
+                usleep($sleepTime);
+
+                // if during the start and the current read url the cli has been disable we need to return from the function
+                // mark the process NOT as ended.
+                if ($this->getCrawler()->isDisabled()) {
+                    return ($result | self::CLI_STATUS_ABORTED);
+                }
+
+                if (! $this->getProcessRepository()->isProcessActive($this->getProcessId())) {
+                    $result |= self::CLI_STATUS_ABORTED;
+                    //possible timeout
+                    break;
+                }
+            }
+
+            sleep($sleepAfterFinish);
+        }
+
+        if ($counter > 0) {
+            $result |= self::CLI_STATUS_PROCESSED;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Try to acquire a new process with the given id
+     * also performs some auto-cleanup for orphan processes
+     */
+    private function checkAndAcquireNewProcess(string $id): bool
+    {
+        $returnValue = true;
+
+        $systemProcessId = getmypid();
+        if (! $systemProcessId) {
+            return false;
+        }
+
+        $processCount = 0;
+        $orphanProcesses = [];
+
+        $activeProcesses = $this->getProcessRepository()->findAllActive();
+
+        /** @var Process $process */
+        foreach ($activeProcesses as $process) {
+            if ($process->getTtl() < time()) {
+                $orphanProcesses[] = $process->getProcessId();
+            } else {
+                $processCount++;
+            }
+        }
+
+        // if there are less than allowed active processes then add a new one
+        if ($processCount < (int) $this->extensionSettings['processLimit']) {
+            $this->getProcessRepository()->addProcess($id, $systemProcessId);
+        } else {
+            $returnValue = false;
+        }
+
+        $this->getProcessRepository()->deleteProcessesMarkedAsDeleted();
+        $this->getProcessRepository()->markRequestedProcessesAsNotActive($orphanProcesses);
+        $this->getQueueRepository()->unsetProcessScheduledAndProcessIdForQueueEntries($orphanProcesses);
+
+        return $returnValue;
+    }
+
+    /**
+     * Create a unique Id for the current process
+     */
+    private function getProcessId(): string
+    {
+        if (! $this->processId) {
+            $this->processId = GeneralUtility::shortMD5(microtime(true));
+        }
+        return $this->processId;
+    }
+
+    private function getCrawler(): Crawler
+    {
+        return $this->crawler ?? new Crawler();
+    }
+
+    private function getCrawlerController(): CrawlerController
+    {
+        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+        return $this->crawlerController ?? $objectManager->get(CrawlerController::class);
+    }
+
+    private function getProcessRepository(): ProcessRepository
+    {
+        return $this->processRepository ?? new ProcessRepository();
+    }
+
+    private function getQueueRepository(): QueueRepository
+    {
+        return $this->queueRepository ?? new QueueRepository();
+    }
+
+    private function getExtensionSettings(): array
+    {
+        return GeneralUtility::makeInstance(ExtensionConfigurationProvider::class)->getExtensionConfiguration();
     }
 }

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -83,17 +83,32 @@ class CrawlerController implements LoggerAwareInterface
     use PublicMethodDeprecationTrait;
     use PublicPropertyDeprecationTrait;
 
+    /**
+     * @deprecated since 9.2.5 will be removed in v11.x
+     */
     public const CLI_STATUS_NOTHING_PROCCESSED = 0;
 
-    //queue not empty
+    /**
+     * queue not empty
+     * @deprecated since 9.2.5 will be removed in v11.x
+     */
     public const CLI_STATUS_REMAIN = 1;
 
-    //(some) queue items where processed
+    /**
+     * (some) queue items where processed
+     * @deprecated since 9.2.5 will be removed in v11.x
+     */
     public const CLI_STATUS_PROCESSED = 2;
 
-    //instance didn't finish
+    /**
+     * instance didn't finish
+     * @deprecated since 9.2.5 will be removed in v11.x
+     */
     public const CLI_STATUS_ABORTED = 4;
 
+    /**
+     * @deprecated since 9.2.5 will be removed in v11.x
+     */
     public const CLI_STATUS_POLLABLE_PROCESSED = 8;
 
     /**
@@ -209,8 +224,11 @@ class CrawlerController implements LoggerAwareInterface
      */
     private $deprecatedPublicMethods = [
         'cleanUpOldQueueEntries' => 'Using CrawlerController::cleanUpOldQueueEntries() is deprecated since 9.0.1 and will be removed in v11.x, please use QueueRepository->cleanUpOldQueueEntries() instead.',
+        'CLI_buildProcessId' => 'Using CrawlerController->CLI_buildProcessId() is deprecated since 9.2.5 and will be removed in v11.x',
+        'CLI_checkAndAcquireNewProcess' => 'Using CrawlerController->CLI_checkAndAcquireNewProcess() is deprecated since 9.2.5 and will be removed in v11.x',
         'CLI_debug' => 'Using CrawlerController->CLI_debug() is deprecated since 9.1.3 and will be removed in v11.x',
         'CLI_releaseProcesses' => 'Using CrawlerController->CLI_releaseProcesses() is deprecated since 9.2.2 and will be removed in v11.x',
+        'CLI_run' => 'Using CrawlerController->CLI_run() is deprecated since 9.2.2 and will be removed in v11.x',
         'CLI_runHooks' => 'Using CrawlerController->CLI_runHooks() is deprecated since 9.1.5 and will be removed in v11.x',
         'getAccessMode' => 'Using CrawlerController->getAccessMode() is deprecated since 9.1.3 and will be removed in v11.x',
         'getLogEntriesForPageId' => 'Using CrawlerController->getLogEntriesForPageId() is deprecated since 9.1.5 and will be remove in v11.x',
@@ -223,7 +241,7 @@ class CrawlerController implements LoggerAwareInterface
         'getProcessFilename' => 'Using CrawlerController->getProcessFilename() is deprecated since 9.1.3 and will be removed in v11.x',
         'setProcessFilename' => 'Using CrawlerController->setProcessFilename() is deprecated since 9.1.3 and will be removed in v11.x',
         'getDuplicateRowsIfExist' => 'Using CrawlerController->getDuplicateRowsIfExist() is deprecated since 9.1.4 and will be remove in v11.x, please use QueueRepository->getDuplicateQueueItemsIfExists() instead',
-        'checkIfPageShouldBeSkipped' => 'Using CrawlerController->checkIfPageShouldBeSkipped() is deprecated since 9.2.5 and will be removed in v11.x'
+        'checkIfPageShouldBeSkipped' => 'Using CrawlerController->checkIfPageShouldBeSkipped() is deprecated since 9.2.5 and will be removed in v11.x',
     ];
 
     /**
@@ -1535,6 +1553,8 @@ class CrawlerController implements LoggerAwareInterface
 
     /**
      * Running the functionality of the CLI (crawling URLs from queue)
+     * @deprecated
+     * @codeCoverageIgnore
      */
     public function CLI_run(int $countInARun, int $sleepTime, int $sleepAfterFinish): int
     {
@@ -1610,6 +1630,7 @@ class CrawlerController implements LoggerAwareInterface
     /**
      * Activate hooks
      * @deprecated
+     * @codeCoverageIgnore
      */
     public function CLI_runHooks(): void
     {
@@ -1627,6 +1648,8 @@ class CrawlerController implements LoggerAwareInterface
      * @param string $id identification string for the process
      * @return boolean
      * @todo preemption might not be the most elegant way to clean up
+     * @deprecated
+     * @codeCoverageIgnore
      */
     public function CLI_checkAndAcquireNewProcess($id)
     {
@@ -1672,6 +1695,7 @@ class CrawlerController implements LoggerAwareInterface
      * @param mixed $releaseIds string with a single process-id or array with multiple process-ids
      * @return boolean
      * @deprecated
+     * @codeCoverageIgnore
      */
     public function CLI_releaseProcesses($releaseIds)
     {
@@ -1724,6 +1748,8 @@ class CrawlerController implements LoggerAwareInterface
      * Create a unique Id for the current process
      *
      * @return string the ID
+     * @deprecated
+     * @codeCoverageIgnore
      */
     public function CLI_buildProcessId()
     {

--- a/composer.json
+++ b/composer.json
@@ -152,6 +152,10 @@
         "test:unit": [
             "[ -e .Build/bin/phpunit ] || composer update",
             "TYPO3_PATH_WEB=.Build/Web .Build/bin/phpunit --colors -c .Build/vendor/nimut/testing-framework/res/Configuration/UnitTests.xml Tests/Unit"
+        ],
+        "test:mutation": [
+            "[ -e .Build/bin/infection ] || composer update",
+            "XDEBUG_MODE=coverage .Build/bin/infection --min-msi=18 --min-covered-msi=92 --threads=8"
         ]
     },
     "repositories": [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -226,6 +226,11 @@ parameters:
 			path: Classes/Command/FlushQueueCommand.php
 
 		-
+			message: "#^Call to an undefined method object\\:\\:crawler_init\\(\\)\\.$#"
+			count: 1
+			path: Classes/Command/ProcessQueueCommand.php
+
+		-
 			message:
 				"""
 					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
@@ -240,7 +245,53 @@ parameters:
 			path: Classes/Command/ProcessQueueCommand.php
 
 		-
+			message:
+				"""
+					#^Fetching deprecated class constant CLI_STATUS_ABORTED of class AOE\\\\Crawler\\\\Command\\\\ProcessQueueCommand\\:
+					since 9\\.2\\.5 will be made private in v11\\.x$#
+				"""
+			count: 6
+			path: Classes/Command/ProcessQueueCommand.php
+
+		-
+			message:
+				"""
+					#^Fetching deprecated class constant CLI_STATUS_NOTHING_PROCCESSED of class AOE\\\\Crawler\\\\Command\\\\ProcessQueueCommand\\:
+					since 9\\.2\\.5 will be made private in v11\\.x$#
+				"""
+			count: 2
+			path: Classes/Command/ProcessQueueCommand.php
+
+		-
+			message:
+				"""
+					#^Fetching deprecated class constant CLI_STATUS_PROCESSED of class AOE\\\\Crawler\\\\Command\\\\ProcessQueueCommand\\:
+					since 9\\.2\\.5 will be made private in v11\\.x$#
+				"""
+			count: 1
+			path: Classes/Command/ProcessQueueCommand.php
+
+		-
+			message:
+				"""
+					#^Fetching deprecated class constant CLI_STATUS_REMAIN of class AOE\\\\Crawler\\\\Command\\\\ProcessQueueCommand\\:
+					since 9\\.2\\.5 will be made private in v11\\.x$#
+				"""
+			count: 1
+			path: Classes/Command/ProcessQueueCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\GeneralUtility\\:\\:shortMD5\\(\\) expects string, float given\\.$#"
+			count: 1
+			path: Classes/Command/ProcessQueueCommand.php
+
+		-
 			message: "#^Parameter \\#1 \\$messages of method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:writeln\\(\\) expects iterable\\|string, int given\\.$#"
+			count: 1
+			path: Classes/Command/ProcessQueueCommand.php
+
+		-
+			message: "#^Unable to resolve the template type T in call to method static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\GeneralUtility\\:\\:makeInstance\\(\\)$#"
 			count: 1
 			path: Classes/Command/ProcessQueueCommand.php
 
@@ -262,11 +313,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method object\\:\\:crawler_init\\(\\)\\.$#"
 			count: 2
-			path: Classes/Controller/CrawlerController.php
-
-		-
-			message: "#^Call to deprecated method CLI_debug\\(\\) of class AOE\\\\Crawler\\\\Controller\\\\CrawlerController\\.$#"
-			count: 1
 			path: Classes/Controller/CrawlerController.php
 
 		-
@@ -334,6 +380,15 @@ parameters:
 
 		-
 			message: "#^Fetching class constant SIGNAL_URL_ADDED_TO_QUEUE of deprecated class AOE\\\\Crawler\\\\Utility\\\\SignalSlotUtility\\.$#"
+			count: 1
+			path: Classes/Controller/CrawlerController.php
+
+		-
+			message:
+				"""
+					#^Fetching deprecated class constant CLI_STATUS_POLLABLE_PROCESSED of class AOE\\\\Crawler\\\\Controller\\\\CrawlerController\\:
+					since 9\\.2\\.5 will be removed in v11\\.x$#
+				"""
 			count: 1
 			path: Classes/Controller/CrawlerController.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -236,7 +236,7 @@ parameters:
 					#^Call to deprecated method get\\(\\) of class TYPO3\\\\CMS\\\\Extbase\\\\Object\\\\ObjectManager\\:
 					since TYPO3 10\\.4, will be removed in version 12\\.0$#
 				"""
-			count: 3
+			count: 2
 			path: Classes/Command/ProcessQueueCommand.php
 
 		-


### PR DESCRIPTION
## Description

This PR Add the CLI_ functions from the CrawlerController to ProcessCommand, there are only used in there, so having the as private functions in there instead of a Service was more logical to me, but still not 100% sure if I like the service approach more to have the ProcessCommand smaller.

**I have**

- [x] Checked that CGL are followed
- [x] Checked that the Tests are still working
- [x] Added description to CHANGELOG.md (github-handle is optional)
- [X] Added tests for the new code
