### PR TITLE
[BUGFIX] Fix type error when exclude subcfg is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+* Fix type error when exclude subcfg is not defined
+
 ### Deprecated
 #### Classes
 #### Functions & Properties

--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -1350,7 +1350,7 @@ class CrawlerController implements LoggerAwareInterface
                     $titleClm = '';
                 }
 
-                if (! in_array($pageRow['uid'], $this->configurationService->expandExcludeString($confArray['subCfg']['exclude']), true)) {
+                if (! in_array($pageRow['uid'], $this->configurationService->expandExcludeString($confArray['subCfg']['exclude'] ?? ''), true)) {
 
                     // URL list:
                     $urlList = $this->urlListFromUrlArray(


### PR DESCRIPTION
## Bug Report

When calling the buildQueue command, e.g.

`crawler:buildQueue 3 deployment --depth 99 --mode exec`

the following exception is thrown:

`
Uncaught TYPO3 Exception Argument 1 passed to AOE\Crawler\Service\ConfigurationService::expandExcludeString() must be of the type string, null given,
called in /var/www/xxx/releases/215/public/typo3conf/ext/crawler/Classes/Controller/CrawlerController.php on line 1359
thrown in file /var/www/xxx/releases/215/public/typo3conf/ext/crawler/Classes/Service/ConfigurationService.php
in line 169
` 

I have a configuration not as database record but as a TS confguration. Appearently, the "subcfg|exclude" key is not configured which leads to this error.

**Expected behavior/output**
No exception is thrown ;-)

**Steps to reproduce**
Call buildQueue as command with configuration without exclude key.

**Environment**
- Crawler version(s): 9.2.5
- TYPO3 version(s): 10.4.17
- Is your TYPO3 installation set up with Composer (Composer Mode): yes 
