### PR TITLE
Crawler progress state after completly finished always "Process was cancelled"

### DIFF
--- a/Classes/Controller/CrawlerController.php
+++ b/Classes/Controller/CrawlerController.php
@@ -385,6 +385,15 @@ class CrawlerController implements LoggerAwareInterface
     }
 
     /**
+     * @param string $processID
+     * @deprecated
+     */
+    public function setProcessID($processID): void
+    {
+        $this->processID = $processID;
+    }
+
+    /**
      * @return string
      * @deprecated
      */
@@ -1117,6 +1126,8 @@ class CrawlerController implements LoggerAwareInterface
 
         // Set exec_time to lock record:
         $field_array = ['exec_time' => $this->getCurrentTime()];
+
+        $this->setProcessID($queueRec['process_id']);
 
         if (isset($this->processID)) {
             //if mulitprocessing is used we need to store the id of the process which has handled this entry


### PR DESCRIPTION
## Bug Report

**Current Behavior**
Crawler progress state after completly finished always "Process was cancelled"

<img width="2452" alt="cancelled" src="https://user-images.githubusercontent.com/13748683/127633855-cfce8f58-ae03-4f6a-afb6-e816595f2ecf.png">

**Expected behavior/output**
After the crawler progress ist completed, the State should be "Progress completed sucessfully"

<img width="2458" alt="sucessfully" src="https://user-images.githubusercontent.com/13748683/127635204-0df1ea0c-97cf-4d9b-b0f6-2fe11d13ec46.png">


**Steps to reproduce**
Just run the crawler process.

**Environment**
- Crawler version(s): 9.2.6
- TYPO3 version(s): 10.4.18
- Is your TYPO3 installation set up with Composer (Composer Mode): no

**Possible Solution**
Following Changes solved the problem for me:

File: `/typo3conf/ext/crawler/Classes/Controller/CrawlerController.php`

I changes this code (line 384):

```
    /**
     * @param string $filenameWithPath
     * @deprecated
     */
    public function setProcessFilename($filenameWithPath): void
    {
        $this->processFilename = $filenameWithPath;
    }
```

to this:

```
    /**
     * @param string $filenameWithPath
     * @deprecated
     */
    public function setProcessFilename($filenameWithPath): void
    {
        $this->processFilename = $filenameWithPath;
    }

    /**
     * @param string $processID
     * @deprecated
     */
    public function setProcessID($processID): void
    {
        $this->processID = $processID;
    }
```

And as second step i changed this code:

```
       if (isset($this->processID)) {
            //if mulitprocessing is used we need to store the id of the process which has handled this entry
            $field_array['process_id_completed'] = $this->processID;
        }
```

to this:

```
       $this->setProcessID($queueRec['process_id']);

       if (isset($this->processID)) {
            //if mulitprocessing is used we need to store the id of the process which has handled this entry
            $field_array['process_id_completed'] = $this->processID;
        }
```

Maybe it helps someone else...
